### PR TITLE
Fix escaping of values in CSV encoding for SASL digest

### DIFF
--- a/src/csvkv.erl
+++ b/src/csvkv.erl
@@ -73,9 +73,10 @@ join(Items, Sep) ->
 
 format_item({Key, Val}, QMark) ->
     EscVal = re:replace(Val, "\"", "\\\"", [global]),
+    EscVal2 = re:replace(EscVal, "\\\\", "\\\\\\\\", [global]),
     case QMark of
         true ->
-            [Key, $=, $", EscVal, $"];
+            [Key, $=, $", EscVal2, $"];
         _ ->
-            [Key, $=, EscVal]
+            [Key, $=, EscVal2]
     end.


### PR DESCRIPTION
Usernames compliant with XEP-0106 were not escaped properly in key-value encoding for SASL Digest.
