### PR TITLE
build fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,8 @@
 
 {deps, [
     {exml, "2\.1\..*", {git, "git://github.com/esl/exml.git", {tag, "2.1.0"}}},
-    {base16, ".*", {git, "git://github.com/goj/base16.git", {branch, "master"}}},
-    {lhttpc, ".*", {git, "git://github.com/esl/lhttpc.git", {branch, "master"}}},
+    {base16, ".*", {git, "git://github.com/goj/base16.git", "ec420aa"}},
+    {lhttpc, ".*", {git, "git://github.com/esl/lhttpc.git", "3c7fdee"}},
     {wsock , ".*", {git, "git://github.com/madtrick/wsock.git", {tag, "1.1.3"}}},
     {wsecli, ".*", {git, "git://github.com/madtrick/wsecli.git", {tag, "0.1.0"}}}
 ]}.


### PR DESCRIPTION
Some changes in `wsock` library caused compilation to fail. Now we pull `wsock` in wright version before `wsecli` can pull bad one.  In addition we pull all other deps by commit, which sure protect us before such situation in future.

Bumping tag to this commit also should be considered (since we do not relay introduce any logic changes, and wright now pulling `2.3.1` causes failure in applications that uses this as dependency).
