### PR TITLE
Cleanup and spec `escalus_users` and some coupled external functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
         - make
         - make test
         - make ct
+        - make dialyzer
 
 after_script:
         - make mongooseim-stop

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ escalus_plt: dialyzer/escalus.plt
 
 dialyzer: erlang_plt deps_plt escalus_plt
 	@dialyzer --plts dialyzer/*.plt --no_check_plt \
-	--get_warnings -o dialyzer/error.log ebin; \
-	status=$$? ; if [ $$status -ne 2 ]; then exit $$status; else exit 0; fi
+	--get_warnings -o dialyzer/error.log ebin
 
 MIM := deps/mongooseim
 MIM_REL := ${MIM}/rel/mongooseim

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]},
-            {platform_define, "R1[45]", no_binary_to_integer}]}.
+            {platform_define, "R1[45]", no_binary_to_integer},
+            {platform_define, "R15", no_types_with_arities}]}.
 
 {require_otp_vsn, "R?1[4567]"}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, [debug_info,
+            warn_missing_spec,
             {i, ["include"]},
             {platform_define, "R1[45]", no_binary_to_integer},
             {platform_define, "R15", no_types_with_arities}]}.

--- a/src/escalus.erl
+++ b/src/escalus.erl
@@ -40,12 +40,16 @@
          wait_for_stanzas/3,
          peek_stanzas/1]).
 
--export_type([config/0]).
+-export_type([client/0,
+              config/0]).
+
+-include("escalus.hrl").
 
 %%--------------------------------------------------------------------
 %% Public Types
 %%--------------------------------------------------------------------
 
+-type client() :: #client{}.
 -type config() :: escalus_config:config().
 
 %%--------------------------------------------------------------------

--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -482,7 +482,7 @@ detect_type(Attrs) ->
         {_,         Version} -> {streamstart,Version}
     end.
 
-host_to_list({_,_,_,_} = IP4) -> inet:ntoa(IP4);
-host_to_list({_,_,_,_,_,_,_,_} = IP6) -> inet:ntoa(IP6);
+host_to_list({_,_,_,_} = IP4) -> inet_parse:ntoa(IP4);
+host_to_list({_,_,_,_,_,_,_,_} = IP6) -> inet_parse:ntoa(IP6);
 host_to_list(BHost) when is_binary(BHost) -> binary_to_list(BHost);
 host_to_list(Host) when is_list(Host) -> Host.

--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -44,6 +44,8 @@
 %% Public API
 %%--------------------------------------------------------------------
 
+-spec start(escalus:config(), escalus_users:user_spec(), binary()) -> {ok, _}
+                                                                    | {error, _}.
 start(Config, UserSpec, Resource) ->
     EventClient = escalus_event:new_client(Config, UserSpec, Resource),
     Options = escalus_users:get_options(Config, UserSpec, Resource, EventClient),

--- a/src/escalus_config.erl
+++ b/src/escalus_config.erl
@@ -58,11 +58,11 @@ get_config(Option, Config, Default) ->
             end
     end.
 
--spec get_config(key(), escalus_users:spec(), key(), config()) -> any().
+-spec get_config(key(), escalus_users:user_spec(), key(), config()) -> any().
 get_config(USName, UserSpec, CName, Config) ->
     get_config(USName, UserSpec, CName, Config, undefined).
 
--spec get_config(key(), escalus_users:spec(), key(), config(), any())
+-spec get_config(key(), escalus_users:user_spec(), key(), config(), any())
     -> any().
 get_config(USName, UserSpec, CName, Config, Default) ->
     case lists:keyfind(USName, 1, UserSpec) of

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -38,8 +38,8 @@
 %%% Public API
 %%%===================================================================
 
--spec start(escalus_users:spec()) -> {ok, client(), escalus_users:spec()} |
-                                     {error, any()}.
+-spec start(escalus_users:user_spec()) -> {ok, client(), escalus_users:user_spec()}
+                                        | {error, any()}.
 start(Props) ->
     start(Props,
           [start_stream,
@@ -75,8 +75,8 @@ start(Props) ->
 %% 'maybe_*' will check allowed properties and features to see if it's possible
 %% to use a feature.
 %% Others will assume a feature is available and fail if it's not.
--spec start(escalus_users:spec(),
-            [step_spec()]) -> {ok, client(), escalus_users:spec()} |
+-spec start(escalus_users:user_spec(),
+            [step_spec()]) -> {ok, client(), escalus_users:user_spec()} |
                               {error, any()}.
 start(Props0, Steps) ->
     try

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -128,7 +128,7 @@ send(#client{module = Mod, event_client = EventClient} = Client, Elem) ->
     escalus_event:outgoing_stanza(EventClient, Elem),
     Mod:send(Client, Elem).
 
--spec get_stanza(client(), any()) -> #xmlel{}.
+-spec get_stanza(client(), any()) -> xmlstreamelement().
 get_stanza(Conn, Name) ->
     receive
         {stanza, Conn, Stanza} ->

--- a/src/escalus_ejabberd.erl
+++ b/src/escalus_ejabberd.erl
@@ -167,11 +167,18 @@ wait_for_session_count(Config, Count, _) ->
 %% `reset_option/2` will restore that saved value using the appropriate
 %% setter function and delete it from `Config`.
 
+-ifdef(no_types_with_arities).
+-type option() :: {Name   :: atom(),
+                   Getter :: fun(() -> any()),
+                   Setter :: fun((any()) -> any()),
+                   Value  :: any()}.
+-else.
 -type option(Type) :: {Name   :: atom(),
                        Getter :: fun(() -> Type),
                        Setter :: fun((Type) -> any()),
                        Value  :: Type}.
 -type option() :: option(_).
+-endif.
 
 -spec setup_option(option(), Config) -> Config.
 setup_option({Option, Get, Set, Value}, Config) ->

--- a/src/escalus_event.erl
+++ b/src/escalus_event.erl
@@ -143,7 +143,10 @@ build_stanza_event_elem(Type, JID, BaseTime, Time, Elem) ->
         children = [Elem || Elem =/= undefined]}.
 
 manager(Config) ->
-    proplists:get_value(escalus_event_mgr, Config).
+    case proplists:get_value(escalus_event_mgr, Config) of
+        undefined -> error(no_event_mgr, [Config]);
+        Mgr -> Mgr
+    end.
 
 %% @doc Create a new event emitter.
 new_client(Config, User, MaybeResource) when is_list(Config) ->
@@ -154,8 +157,6 @@ new_client(Config, User, MaybeResource) when is_list(Config) ->
 maybe_resource_to_binary(undefined) -> <<>>;
 maybe_resource_to_binary(Resource) when is_binary(Resource) -> Resource.
 
-new_client_1(undefined, _UserSpec, _Resource) ->
-    undefined;
 new_client_1(Mgr, UserSpec, Resource) ->
     [{event_manager, Mgr},
      {server, proplists:get_value(server, UserSpec)},

--- a/src/escalus_event.erl
+++ b/src/escalus_event.erl
@@ -18,6 +18,8 @@
 -export([get_history/1,
          print_history/1]).
 
+-export_type([event_client/0]).
+
 -include_lib("exml/include/exml.hrl").
 -include("no_binary_to_integer.hrl").
 
@@ -157,6 +159,9 @@ new_client(Config, User, MaybeResource) when is_list(Config) ->
 maybe_resource_to_binary(undefined) -> <<>>;
 maybe_resource_to_binary(Resource) when is_binary(Resource) -> Resource.
 
+-type event_client() :: list({atom(), any()}).
+
+-spec new_client_1(any(), escalus_users:user_spec(), binary()) -> event_client().
 new_client_1(Mgr, UserSpec, Resource) ->
     [{event_manager, Mgr},
      {server, proplists:get_value(server, UserSpec)},

--- a/src/escalus_pred.erl
+++ b/src/escalus_pred.erl
@@ -167,7 +167,7 @@ is_forwarded_received_message(OriginalFrom, OriginalTo, Msg, Stanza) ->
 is_forwarded_sent_message(OriginalFrom, OriginalTo, Msg, Stanza) ->
     has_carbon(<<"sent">>, OriginalFrom, OriginalTo, Msg, Stanza).
 
--spec has_carbon(binary(), binary(), binary(), binary(), binary()) -> boolean().
+-spec has_carbon(binary(), binary(), binary(), binary(), xmlterm()) -> boolean().
 has_carbon(Type, From, To, Msg, Stanza) ->
     Carbon = exml_query:subelement(Stanza, Type),
     has_ns(?NS_CARBONS_2, Carbon)

--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -38,13 +38,13 @@
 -export_type([features/0]).
 
 -define(CONNECTION_STEP, (escalus_connection:client(),
-                          escalus_users:spec(),
+                          escalus_users:user_spec(),
                           features()) -> step_state()).
 -type step() :: fun(?CONNECTION_STEP).
 -export_type([step/0]).
 
 -type step_state() :: {escalus_connection:client(),
-                       escalus_users:spec(),
+                       escalus_users:user_spec(),
                        features()}.
 -export_type([step_state/0]).
 
@@ -122,7 +122,7 @@ use_ssl(Props, Features) ->
         _ -> false
     end.
 
--spec can_use_compression(escalus_users:spec(), features()) -> boolean().
+-spec can_use_compression(escalus_users:user_spec(), features()) -> boolean().
 can_use_compression(Props, Features) ->
     can_use(compression, Props, Features).
 

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -661,9 +661,6 @@ direction_el('after', AbstractID) when is_binary(AbstractID) ->
 direction_el('before', AbstractID) when is_binary(AbstractID) ->
     #xmlel{name = <<"before">>, children = #xmlcdata{content = AbstractID}}.
 
-max(N) when is_integer(N) ->
-    #xmlel{name = <<"max">>, children = #xmlcdata{content = integer_to_binary(N)}}.
-
 mam_ns_attr() -> {<<"xmlns">>,?NS_MAM}.
 
 

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -643,13 +643,13 @@ fmapM(F, MaybeVal) -> F(MaybeVal).
 defined(L) when is_list(L) -> [ El || El <- L, El /= undefined ].
 
 start_elem(StartTime) ->
-    #xmlel{name = <<"start">>, children = #xmlcdata{content = StartTime}}.
+    #xmlel{name = <<"start">>, children = [#xmlcdata{content = StartTime}]}.
 
 end_elem(EndTime) ->
-    #xmlel{name = <<"end">>, children = #xmlcdata{content = EndTime}}.
+    #xmlel{name = <<"end">>, children = [#xmlcdata{content = EndTime}]}.
 
 with_elem(BWithJID) ->
-    #xmlel{name = <<"with">>, children = #xmlcdata{content = BWithJID}}.
+    #xmlel{name = <<"with">>, children = [#xmlcdata{content = BWithJID}]}.
 
 rsm_after_or_before({Direction, AbstractID}) when is_binary(AbstractID) ->
     #xmlel{name = <<"set">>,
@@ -657,9 +657,9 @@ rsm_after_or_before({Direction, AbstractID}) when is_binary(AbstractID) ->
            children = [ direction_el(Direction, AbstractID) ]}.
 
 direction_el('after', AbstractID) when is_binary(AbstractID) ->
-    #xmlel{name = <<"after">>, children = #xmlcdata{content = AbstractID}};
+    #xmlel{name = <<"after">>, children = [#xmlcdata{content = AbstractID}]};
 direction_el('before', AbstractID) when is_binary(AbstractID) ->
-    #xmlel{name = <<"before">>, children = #xmlcdata{content = AbstractID}}.
+    #xmlel{name = <<"before">>, children = [#xmlcdata{content = AbstractID}]}.
 
 mam_ns_attr() -> {<<"xmlns">>,?NS_MAM}.
 

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -50,15 +50,13 @@
               who/0]).
 
 %% Public types
--type who() :: all | {by_name, [escalus_config:key()]} | [named_user()].
-
--type user() :: user_name() | user_spec().
-
--type user_name() :: atom().
--type named_user() :: {user_name(), user_spec()}.
+-type who() :: all | {by_name, [escalus_config:key()]}.
 -type user_spec() :: [{user_option(), any()}].
 
-%% Not yet public types
+%% Internal types
+-type user() :: user_name() | user_spec().
+-type named_user() :: {user_name(), user_spec()}.
+-type user_name() :: atom().
 -type host() :: inet:hostname() | inet:ip4_address() | binary().
 -type xmpp_domain() :: inet:hostname() | binary().
 

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -60,8 +60,6 @@
 -type host() :: inet:hostname() | inet:ip4_address() | binary().
 -type xmpp_domain() :: inet:hostname() | binary().
 
--import(escalus_compat, [bin/1]).
-
 -include("include/escalus.hrl").
 -include_lib("exml/include/exml.hrl").
 
@@ -201,7 +199,7 @@ get_options(Config, User) ->
 
 -spec get_options(escalus:config(), user(), binary()) -> escalus:config().
 get_options(Config, User, Resource) ->
-    [{resource, bin(Resource)} | get_options(Config, User)].
+    [{resource, Resource} | get_options(Config, User)].
 
 -spec get_options(escalus:config(), user(),
                   binary(), escalus_event:event_client()) -> escalus:config().

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -229,9 +229,7 @@ get_users(all) ->
     escalus_ct:get_config(escalus_users);
 get_users({by_name, Names}) ->
     All = get_users(all),
-    [get_user_by_name(Name, All) || Name <- Names];
-get_users(Users) ->
-    Users.
+    [get_user_by_name(Name, All) || Name <- Names].
 
 -spec get_user_by_name(atom()) -> {atom(), escalus:config()}.
 get_user_by_name(Name) ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -314,21 +314,21 @@ is_mod_register_enabled(Config) ->
 get_user_by_name(Name, Users) ->
     {Name, _} = proplists:lookup(Name, Users).
 
--type short_option() :: 'username'    %% binary()
-                      | 'server'      %% binary()
-                      | 'password'    %% binary()
-                      | 'compression' %% <<"zlib">> | false
-                      | 'ssl'         %% 'false' | 'optional',
-                                      %% shouldn't there also be 'required'?
-                      | 'transport'   %% 'tcp' | 'bosh' | 'ws', anything else?
-                      | 'path'        %% BOSH path
-                      | 'port'        %% TCP port
-                      | 'wspath'      %% WebSocket path - unify with `path`?
-                      | 'host'        %% IP address? DNS name?
-                      | 'auth_method' %% <<"PLAIN">> | <<"DIGETS-MD5">>
-                                      %% | <<"SASL-ANON">> | <<"SCRAM-SHA-1">>
-                                      %% | Other
-                      .
+-type user_option() :: 'username'    %% binary()
+                     | 'server'      %% binary()
+                     | 'password'    %% binary()
+                     | 'compression' %% <<"zlib">> | false
+                     | 'ssl'         %% 'false' | 'optional',
+                                     %% shouldn't there also be 'required'?
+                     | 'transport'   %% 'tcp' | 'bosh' | 'ws', anything else?
+                     | 'path'        %% BOSH path
+                     | 'port'        %% TCP port
+                     | 'wspath'      %% WebSocket path - unify with `path`?
+                     | 'host'        %% IP address? DNS name?
+                     | 'auth_method' %% <<"PLAIN">> | <<"DIGETS-MD5">>
+                                     %% | <<"SASL-ANON">> | <<"SCRAM-SHA-1">>
+                                     %% | Other
+                     .
 
 -type ejabberd_option() :: 'ejabberd_node'
                          | 'ejabberd_cookie'
@@ -350,7 +350,7 @@ get_user_by_name(Name, Users) ->
 %% get_user_option is a wrapper on escalus_config:get_config/5,
 %% which can take either UserSpec (a proplist) or user name (atom)
 %% as the second argument
--spec get_user_option(short_option(), user(), long_option(),
+-spec get_user_option(user_option(), user(), long_option(),
                       escalus:config(), option_value()) -> option_value().
 get_user_option(Short, Name, Long, Config, Default) when is_atom(Name) ->
     {Name, Spec} = case lists:keysearch(escalus_users, 1, Config) of
@@ -364,7 +364,7 @@ get_user_option(Short, Spec, Long, Config, Default) ->
     escalus_config:get_config(Short, Spec, Long, Config, Default).
 
 -spec get_defined_option(escalus:config(), user(),
-                         short_option(), long_option()) -> option_value().
+                         user_option(), long_option()) -> option_value().
 get_defined_option(Config, Name, Short, Long) ->
     case get_user_option(Short, Name, Long, Config, undefined) of
         undefined ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -307,12 +307,48 @@ is_mod_register_enabled(Config) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
+-spec get_user_by_name(atom(), escalus:config()) -> {atom(), escalus:config()}.
 get_user_by_name(Name, Users) ->
     {Name, _} = proplists:lookup(Name, Users).
+
+-type short_option() :: 'username'    %% binary()
+                      | 'server'      %% binary()
+                      | 'password'    %% binary()
+                      | 'compression' %% <<"zlib">> | false
+                      | 'ssl'         %% 'false' | 'optional',
+                                      %% shouldn't there also be 'required'?
+                      | 'transport'   %% 'tcp' | 'bosh' | 'ws', anything else?
+                      | 'path'        %% BOSH path
+                      | 'port'        %% TCP port
+                      | 'wspath'      %% WebSocket path - unify with `path`?
+                      | 'host'        %% IP address? DNS name?
+                      | 'auth_method' %% <<"PLAIN">> | <<"DIGETS-MD5">>
+                                      %% | <<"SASL-ANON">> | <<"SCRAM-SHA-1">>
+                                      %% | Other
+                      .
+
+-type ejabberd_option() :: 'ejabberd_node'
+                         | 'ejabberd_cookie'
+                         | 'ejabberd_domain'.
+
+-type escalus_option() :: 'escalus_server'
+                        | 'escalus_username'
+                        | 'escalus_password'
+                        | 'escalus_host'
+                        | 'escalus_port'
+                        | 'escalus_auth_method'
+                        | 'escalus_wspath'
+                        .
+
+-type long_option() :: ejabberd_option() | escalus_option().
+
+-type option_value() :: any().
 
 %% get_user_option is a wrapper on escalus_config:get_config/5,
 %% which can take either UserSpec (a proplist) or user name (atom)
 %% as the second argument
+-spec get_user_option(short_option(), atom() | escalus:config(), long_option(),
+                      escalus:config(), option_value()) -> option_value().
 get_user_option(Short, Name, Long, Config, Default) when is_atom(Name) ->
     {Name, Spec} = case lists:keysearch(escalus_users, 1, Config) of
         false ->
@@ -324,6 +360,8 @@ get_user_option(Short, Name, Long, Config, Default) when is_atom(Name) ->
 get_user_option(Short, Spec, Long, Config, Default) ->
     escalus_config:get_config(Short, Spec, Long, Config, Default).
 
+-spec get_defined_option(escalus:config(), atom() | escalus:config(),
+                         short_option(), long_option()) -> option_value().
 get_defined_option(Config, Name, Short, Long) ->
     case get_user_option(Short, Name, Long, Config, undefined) of
         undefined ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -45,14 +45,6 @@
          is_mod_register_enabled/1
         ]).
 
-%% Deprecated API
--export([create_user/1,
-         delete_user/1,
-         get_usp/1,
-         get_jid/1,
-         get_username/1,
-         get_server/1]).
-
 %% Public types
 -export_type([spec/0,
               who/0]).
@@ -313,27 +305,6 @@ is_mod_register_enabled(Config) ->
         _ ->
             true
     end.
-
-%%--------------------------------------------------------------------
-%% Deprecated API
-%%--------------------------------------------------------------------
-
--define(DEFINE_ONE_ARG(FUNCTION_NAME),
-        FUNCTION_NAME(Username) ->
-            error_logger:info_msg("Calling deprecated ~p:~p/1,"
-                                  " please call a version with Config"
-                                  " as additional first argument.~n"
-                                  "Backtrace: ~p~n.",
-                                  [?MODULE, FUNCTION_NAME,
-                                   escalus_compat:backtrace(0)]),
-            FUNCTION_NAME([], Username)).
-
-?DEFINE_ONE_ARG(create_user).
-?DEFINE_ONE_ARG(delete_user).
-?DEFINE_ONE_ARG(get_usp).
-?DEFINE_ONE_ARG(get_jid).
-?DEFINE_ONE_ARG(get_username).
-?DEFINE_ONE_ARG(get_server).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -217,6 +217,9 @@ get_users(Users) ->
 get_user_by_name(Name) ->
     get_user_by_name(Name, get_users(all)).
 
+-spec create_user(escalus:config(),
+                  {atom(), escalus_config:key() | escalus:config()}) ->
+    {ok, any(), xmlterm()} | {error, any(), xmlterm()}.
 create_user(Config, {_Name, UserSpec}) ->
     ClientProps = get_options(Config, UserSpec),
     {ok, Conn, ClientProps, _} = escalus_connection:start(ClientProps,
@@ -370,6 +373,10 @@ get_defined_option(Config, Name, Short, Long) ->
             Value
     end.
 
+-spec wait_for_result(escalus:client()) -> {ok, result, xmlterm()}
+                                         | {ok, conflict, xmlterm()}
+                                         | {error, Error, xmlterm()}
+      when Error :: 'failed_to_register' | 'bad_response' | 'timeout'.
 wait_for_result(Conn) ->
     receive
         {stanza, Conn, Stanza} ->


### PR DESCRIPTION
Another batch of type specs for Escalus.
Some exported functions are dropped or change the API, so this requires a version bump. I xreffed against tests (d387738) - none of the dropped stuff seemed to be in use.
A Dialyzer check is now enabled on Travis, so any type error or warning will cause the build to fail.