### PR TITLE
Reduction of escalus crashes when things go wrong & Timeout parameter accepted

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -247,20 +247,23 @@ init([Args, Owner]) ->
     {MS, S, MMS} = now(),
     InitRid = MS * 1000000 * 1000000 + S * 1000000 + MMS,
     {ok, Parser} = exml_stream:new_parser(),
-    {ok, Client} = fusco_cp:start_link({HostStr, Port, false},
+    case fusco_cp:start_link({HostStr, Port, false},
                                        [{on_connect, OnConnectFun}],
                                        %% Max two connections as per BOSH rfc
-                                       2),
-    {ok, #state{owner = Owner,
-                url = Path,
-                parser = Parser,
-                rid = InitRid,
-                keepalive = proplists:get_value(keepalive, Args, true),
-                wait = Wait,
-                event_client = EventClient,
-                client = Client,
-                on_reply = OnReplyFun}}.
-
+                                       2) of
+        {ok, Client} ->
+            {ok, #state{owner = Owner,
+                        url = Path,
+                        parser = Parser,
+                        rid = InitRid,
+                        keepalive = proplists:get_value(keepalive, Args, true),
+                        wait = Wait,
+                        event_client = EventClient,
+                        client = Client,
+                        on_reply = OnReplyFun}};
+        {error, Reason} ->
+            {stop, {shutdown, Reason}}
+    end.
 
 handle_call(get_transport, _From, State) ->
     {reply, transport(State), State};
@@ -295,7 +298,8 @@ handle_call(get_requests, _From, State) ->
 
 handle_call(stop, _From, #state{} = State) ->
     StreamEnd = escalus_stanza:stream_end(),
-    {ok, _Reply, NewState} =
+    % We are stopping so don't care if streamend send failed
+    {_, _Reply, NewState} =
     sync_send0(transport(State), exml:to_iolist(StreamEnd), State),
     {stop, normal, ok, NewState}.
 
@@ -320,20 +324,25 @@ handle_cast(reset_parser, #state{parser = Parser} = State) ->
 
 
 %% Handle async HTTP request replies.
-handle_info({http_reply, Ref, Body, Transport}, S) ->
+handle_info({http_reply, Ref, Body, Transport}, #state{owner = Owner} = S) ->
     NewRequests = lists:keydelete(Ref, 1, S#state.requests),
-    {ok, #xmlel{attrs=Attrs} = XmlBody} = exml:parse(Body),
-    NS = handle_data(XmlBody, S#state{requests = NewRequests}),
-    NNS = case {detect_type(Attrs), NS#state.keepalive, NS#state.requests == []}
-          of
-              {streamend, _, _} -> close_requests(NS#state{terminated=true});
-              {_, false, _}     -> NS;
-              {_, true, true}   -> send(Transport, 
-                                        empty_body(NS#state.rid, NS#state.sid),
-                                        NS);
-              {_, true, false}  -> NS
-    end,
-    {noreply, NNS};
+    case exml:parse(Body) of
+        {ok, #xmlel{attrs=Attrs} = XmlBody} ->     
+            NS = handle_data(XmlBody, S#state{requests = NewRequests}),
+            NNS = case {detect_type(Attrs), NS#state.keepalive, NS#state.requests == []}
+            of
+                {streamend, _, _} -> close_requests(NS#state{terminated=true});
+                {_, false, _}     -> NS;
+                {_, true, true}   -> send(Transport, 
+                                          empty_body(NS#state.rid, NS#state.sid),
+                                          NS);
+                {_, true, false}  -> NS
+            end,
+            {noreply, NNS};
+        {error, _} ->
+            Owner ! {error, parse_error},
+            {noreply, S}
+    end;
 handle_info(_, State) ->
     {noreply, State}.
 
@@ -357,8 +366,12 @@ request(#client{socket = {Client, Path}}, Body, OnReplyFun) ->
         fusco_cp:request(Client, Path, "POST", Headers, exml:to_iolist(Body),
                          2, infinity),
     OnReplyFun(Reply),
-    {ok, {_Status, _Headers, RBody, _Size, _Time}} = Reply,
-    {ok, RBody}.
+    case Reply of
+        {ok, {_Status, _Headers, RBody, _Size, _Time}} ->
+            {ok, RBody};
+        {error, _} = Error ->
+            Error
+    end.
 
 close_requests(#state{requests=Reqs} = S) ->
     [exit(Pid, normal) || {_Ref, Pid} <- Reqs],
@@ -375,8 +388,12 @@ send(Transport, Body, NewRid, #state{requests = Requests, on_reply = OnReplyFun}
     Ref = make_ref(),
     Self = self(),
     AsyncReq = fun() ->
-            {ok, Reply} = request(Transport, Body, OnReplyFun),
-            Self ! {http_reply, Ref, Reply, Transport}
+            case request(Transport, Body, OnReplyFun) of
+                {ok, Reply} ->
+                    Self ! {http_reply, Ref, Reply, Transport};
+                {error, _} = Error ->
+                    Error
+            end
     end,
     NewRequests = [{Ref, proc_lib:spawn_link(AsyncReq)} | Requests],
     S#state{rid = NewRid, requests = NewRequests}.
@@ -385,8 +402,12 @@ sync_send(_, _, S=#state{terminated = true}) ->
     %% Sending anything to a terminated session is pointless. We're done.
     {ok, already_terminated, S};
 sync_send(Transport, Body, S=#state{on_reply = OnReplyFun}) ->
-    {ok, Reply} = request(Transport, Body, OnReplyFun),
-    {ok, Reply, S#state{rid = S#state.rid+1}}.
+    case request(Transport, Body, OnReplyFun) of
+        {ok, Reply} ->
+            {ok, Reply, S#state{rid = S#state.rid+1}};
+        {error, Reason} ->
+            {error, Reason, S}
+    end.
 
 send0(Transport, Elem, State) ->
     send(Transport, wrap_elem(Elem, State), State).

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -100,7 +100,7 @@ connection_step(Step, {Conn, Props, Features}) ->
                 apply(Fun, [Conn, Props, Features])
         end
     catch
-        Error ->
+       _:Error ->
             (Conn#client.module):stop(Conn),
             throw({connection_step_failed, {Step, Conn, Props, Features}, Error})
     end.


### PR DESCRIPTION
See commit messages for changes

Justification:
As soon as target systems started timing out, or didn't exist we were generating error logs with hundreds of thousands of entries due to having a few thousand concurrent escalus connections running. We instead wanted to record these issues using the onX functions passed as parameters. Have tried to change so all failures in setting up the connection are caught under the connection step and returned with the connection step failing. Inside the clients themselves tried to minimize the chance of mostly badmatches happening, reporting what we can back to the owner. Will freely admit some of the decisions are a bit hacky and not very nice but open to ideas on a better way to do this. We just needed to avoid crashes as much as possible in normal operation (which involves things not going to plan!).

Timeout is self explanatory and should have 0 functional changes if ignored.
