### PR TITLE
Websocket default values fixes

### DIFF
--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -89,7 +89,7 @@ get_transport(#client{rcv_pid = Pid}) ->
 
 init([Args, Owner]) ->
     Host = get_host(Args, "localhost"),
-    Port = get_port(Args, 5222),
+    Port = get_port(Args, 5280),
     Resource = get_resource(Args, "/ws-xmpp"),
     LegacyWS = get_legacy_ws(Args, false),
     EventClient = proplists:get_value(event_client, Args),


### PR DESCRIPTION
Default resource was incorrect, required the slash as bosh does.
Default port change to mimic bosh. 
