### PR TITLE
Be ready for <stream:error> when validating authentication

### DIFF
--- a/src/escalus_auth.erl
+++ b/src/escalus_auth.erl
@@ -191,7 +191,7 @@ wait_for_success(Username, Conn) ->
     case AuthReply#xmlel.name of
         <<"success">> ->
             ok;
-        <<"failure">> ->
+        R when R =:= <<"failure">> orelse R =:= <<"stream:error">> ->
             throw({auth_failed, Username, AuthReply})
     end.
 


### PR DESCRIPTION
escalus_auth:wait_for_success/2 was crashing up on receiving
stream:error. Such a situation occurs when a client tries to
authenticate before <starttls> was issued and TLS is required by
the server.
