### PR TITLE
Unify escalus_user_db behaviour

### DIFF
--- a/src/escalus_ejabberd.erl
+++ b/src/escalus_ejabberd.erl
@@ -19,17 +19,19 @@
 
 -module(escalus_ejabberd).
 
-%% TODO: fix interface to comply with escalus_user_db behaviour
-%-behaviour(escalus_user_db).
+-behaviour(escalus_user_db).
+%% escalus_user_db callbacks
+-export([start/1,
+         stop/1,
+         create_users/1,
+         create_users/2,
+         delete_users/1,
+         delete_users/2]).
 
 -export([rpc/3,
          remote_display/1,
          remote_format/1,
          remote_format/2,
-         create_users/1,
-         create_users/2,
-         delete_users/1,
-         delete_users/2,
          get_global_option/1,
          with_global_option/3,
          with_local_option/3,
@@ -44,8 +46,45 @@
          reset_option/2]).
 
 
-
 -include("include/escalus.hrl").
+
+
+%%%
+%%% Escalus_users API
+%%%
+
+start(_Opts) -> ok.
+stop(_Opts) -> ok.
+
+create_users(Config) ->
+    create_users(Config, all).
+
+create_users(Config, Who) ->
+    AllUsers = escalus_users:get_users(Who),
+    lists:foreach(fun({_Name, UserSpec}) ->
+        register_user(Config, UserSpec)
+    end, AllUsers),
+    Config.
+
+delete_users(Config) ->
+    AllUsers = escalus_config:get_config(escalus_users, Config),
+    lists:foreach(fun({_Name, UserSpec}) ->
+        unregister_user(Config, UserSpec)
+    end, AllUsers).
+
+delete_users(Config, Who) when is_atom(Who); is_tuple(Who) ->
+    Users = escalus_users:get_users(Who),
+    delete_users(Config, Users);
+
+delete_users(Config, Users) ->
+    lists:foreach(fun({_Name, UserSpec}) ->
+        unregister_user(Config, UserSpec)
+    end, Users).
+
+
+%%%
+%%% Business API
+%%%
 
 rpc(M, F, A) ->
     Node = escalus_ct:get_config(ejabberd_node),
@@ -64,33 +103,6 @@ remote_format(Format, Args) ->
     io:format(Format, Args),
     group_leader(whereis(user), self()).
 
-% API - compatible with escalus_users:create_users/1
-create_users(Config) ->
-    create_users(Config, all).
-
-% API - compatible with escalus_users:create_users/2
-create_users(Config, Who) ->
-    AllUsers = escalus_users:get_users(Who),
-    lists:foreach(fun({_Name, UserSpec}) ->
-        register_user(Config, UserSpec)
-    end, AllUsers),
-    Config.
-
-% API - compatible with escalus_users:delete_users/1
-delete_users(Config) ->
-    AllUsers = escalus_config:get_config(escalus_users, Config),
-    lists:foreach(fun({_Name, UserSpec}) ->
-        unregister_user(Config, UserSpec)
-    end, AllUsers).
-
-delete_users(Config, Who) when is_atom(Who); is_tuple(Who) ->
-    Users = escalus_users:get_users(Who),
-    delete_users(Config, Users);
-
-delete_users(Config, Users) ->
-    lists:foreach(fun({_Name, UserSpec}) ->
-        unregister_user(Config, UserSpec)
-    end, Users).
 
 -spec get_global_option(term()) -> term().
 get_global_option(Option) ->

--- a/test/test.config
+++ b/test/test.config
@@ -16,6 +16,7 @@
 {ejabberd_secondary_domain, <<"localhost.bis">>}.
 {ejabberd_metrics_rest_port, 5280}.
 {ejabberd_string_format, bin}.
+{escalus_user_db, {module, escalus_ejabberd, []}}.
 
 {escalus_users, [
                  {alice, [


### PR DESCRIPTION
Users can now pass an arbitrary argument to the `escalus_user_db:start/1` function.
The default argument is the empty list.

Usage & documentation is introduced in https://github.com/esl/ejabberd_tests/pull/98
