### PR TITLE
Use BIF-based timers, not timer module

### DIFF
--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -85,9 +85,9 @@ wait_for_stanzas(Client, Count) ->
     wait_for_stanzas(Client, Count, ?WAIT_FOR_STANZA_TIMEOUT).
 
 wait_for_stanzas(Client, Count, Timeout) ->
-    {ok, Tref} = timer:send_after(Timeout, self(), TimeoutMsg={timeout, make_ref()}),
+    Tref = erlang:send_after(Timeout, self(), TimeoutMsg={timeout, make_ref()}),
     Result = do_wait_for_stanzas(Client, Count, TimeoutMsg, []),
-    timer:cancel(Tref),
+    erlang:cancel_timer(Tref),
     Result.
 
 do_wait_for_stanzas(_Client, 0, _TimeoutMsg, Acc) ->


### PR DESCRIPTION
This should improve scalability for uses in load testing or as a standalone app. Not a big deal for functionality testing.
