### PR TITLE
Implement escalus_connection:kill/1 for escalus_bosh transport

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -96,8 +96,9 @@ stop(#client{rcv_pid = Pid}) ->
             already_stopped
     end.
 
-kill(Transport) ->
-    error({not_implemented_for, ?MODULE}, [Transport]).
+kill(#client{} = Client) ->
+    mark_as_terminated(Client),
+    stop(Client).
 
 upgrade_to_tls(#client{} = _Conn, _Props) ->
     not_supported.


### PR DESCRIPTION
This is needed for [testing the BOSH inactivity fix](https://github.com/esl/ejabberd_tests/tree/bosh-inactivity-fix) for which (i.e. the fix) a [PR is waiting](https://github.com/esl/MongooseIM/pull/341).