### PR TITLE
Fix fusco dep to current master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {deps, [
         {exml, ".*", {git, "git://github.com/esl/exml.git", {tag, "2.1.5"}}},
         {base16, ".*", {git, "git://github.com/goj/base16.git", "ec420aa"}},
-        {fusco, ".*", {git, "git://github.com/esl/fusco.git", {branch, "master"}}},
+        {fusco, ".*", {git, "git://github.com/esl/fusco.git", "0a428471"}},
         {wsecli, ".*", {git, "git://github.com/esl/wsecli.git", "bf575f1d04"}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
 ]}.


### PR DESCRIPTION
It is current master, and the same version Megaload depends on at the moment.