### PR TITLE
Build stanzas from raw XML strings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,5 +10,5 @@
         {fusco, ".*", {git, "git://github.com/esl/fusco.git", "0a428471"}},
         {wsecli, ".*", {git, "git://github.com/esl/wsecli.git", "bf575f1d04"}},
         {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
-        {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}}
+        {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", "d0246fe"}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,6 @@
         {base16, ".*", {git, "git://github.com/goj/base16.git", "ec420aa"}},
         {fusco, ".*", {git, "git://github.com/esl/fusco.git", "0a428471"}},
         {wsecli, ".*", {git, "git://github.com/esl/wsecli.git", "bf575f1d04"}},
-        {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
+        {meck, ".*", {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
+        {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}}
 ]}.

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -726,6 +726,10 @@ enable_carbons_el() ->
 %%      {{{argument_will_be_xmlterm}}}
 %%   </example_element>
 %%
+%% It's also possible to substitute whole attributes, not just their values:
+%%
+%%   <example_element {{myattr}}/>
+%%
 %% Refer to escalus_stanza_SUITE for usage examples.
 -type xml_snippet() :: string() | binary().
 
@@ -771,11 +775,14 @@ xml_snippet_to_string(Snippet) when is_binary(Snippet) -> ?b2l(Snippet);
 xml_snippet_to_string(Snippet) -> Snippet.
 
 validate_context(Ctx) ->
-    [ {Key, to_string(Value)} || {Key, Value} <- Ctx ].
+    [ {Key, argument_to_string(Value)} || {Key, Value} <- Ctx ].
 
-to_string(E = #xmlel{}) -> ?b2l(?io2b(exml:to_iolist(E)));
-to_string(E) when is_binary(E) -> ?b2l(E);
-to_string(E) when is_list(E) -> E.
+argument_to_string({Name, Value}) ->
+    ?b2l(?io2b([Name, "='", exml:escape_attr(Value), "'"]));
+argument_to_string(E = #xmlel{}) ->
+    ?b2l(?io2b(exml:to_iolist(E)));
+argument_to_string(E) when is_binary(E) -> ?b2l(E);
+argument_to_string(E) when is_list(E) -> E.
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -115,11 +115,15 @@
 
 -export([remove_account/0]).
 
+%% Stanzas from inline XML
+-export([from_xml/1]).
+
 -import(escalus_compat, [bin/1]).
 
 -include("escalus.hrl").
 -include("escalus_xmlns.hrl").
 -include("no_binary_to_integer.hrl").
+-include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 
 %%--------------------------------------------------------------------
@@ -689,7 +693,25 @@ enable_carbons_el() ->
     #xmlel{name = <<"enable">>,
            attrs = [{<<"xmlns">>, ?NS_CARBONS_2}]}.
 
+%%--------------------------------------------------------------------
+%% Stanzas from inline XML
+%%--------------------------------------------------------------------
 
+-spec from_xml(Snippet) -> Term when
+      Snippet :: string(),
+      Term :: xmlterm().
+from_xml(Snippet) ->
+    to_element(Snippet).
+
+%%--------------------------------------------------------------------
+%% Helpers for stanzas from XML
+%%--------------------------------------------------------------------
+
+to_element(XMLSnippet) when is_binary(XMLSnippet) ->
+    {ok, El} = exml:parse(XMLSnippet),
+    El;
+to_element(XMLSnippet) ->
+    to_element(iolist_to_binary(XMLSnippet)).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -128,6 +128,7 @@
 -include_lib("exml/include/exml_stream.hrl").
 
 -define(b2l(B), erlang:binary_to_list(B)).
+-define(io2b(IOList), erlang:iolist_to_binary(IOList)).
 
 %%--------------------------------------------------------------------
 %% Stream - related functions
@@ -716,6 +717,16 @@ enable_carbons_el() ->
 %%
 %%   <example_element some_attr="{{'fancy:param-name'}}"/>
 %%
+%% If the argument you pass as the parameter value is an xmlterm()
+%% then use triple brackets at the parameter expansion site.
+%% Otherwise, the argument term will end up HTML-encoded
+%% after expansion.
+%%
+%%   <example_element>
+%%      {{{argument_will_be_xmlterm}}}
+%%   </example_element>
+%%
+%% Refer to escalus_stanza_SUITE for usage examples.
 -type xml_snippet() :: string() | binary().
 
 -spec from_xml(Snippet) -> Term when
@@ -762,6 +773,7 @@ xml_snippet_to_string(Snippet) -> Snippet.
 validate_context(Ctx) ->
     [ {Key, to_string(Value)} || {Key, Value} <- Ctx ].
 
+to_string(E = #xmlel{}) -> ?b2l(?io2b(exml:to_iolist(E)));
 to_string(E) when is_binary(E) -> ?b2l(E);
 to_string(E) when is_list(E) -> E.
 

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -12,7 +12,8 @@ all() ->
     [sanity_check,
      nullary_snippet_to_xmlel,
      unary_snippet_to_xmlel,
-     type_matrix_accepted].
+     type_matrix_accepted,
+     term_as_argument].
 
 %%
 %% Tests
@@ -41,3 +42,10 @@ type_matrix_accepted(_) ->
     ?eq(Example, M:from_template(<<"<el attr='{{val}}'/>">>, [{val, "value"}])),
     ?eq(Example, M:from_template(<<"<el attr='{{val}}'/>">>, [{val, <<"value">>}])),
     ?eq(Example, M:from_template("<el attr='{{val}}'/>", [{val, <<"value">>}])).
+
+term_as_argument(_) ->
+    M = escalus_stanza,
+    Inner = #xmlel{name = <<"inner">>},
+    Example = #xmlel{name = <<"outer">>,
+                     children = [Inner]},
+    ?eq(Example, M:from_template("<outer>{{{inner}}}</outer>", [{inner, Inner}])).

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -11,7 +11,8 @@
 all() ->
     [sanity_check,
      nullary_snippet_to_xmlel,
-     unary_snippet_to_xmlel].
+     unary_snippet_to_xmlel,
+     type_matrix_accepted].
 
 %%
 %% Tests
@@ -31,3 +32,12 @@ unary_snippet_to_xmlel(_) ->
                attrs = [{<<"attr">>, <<"value">>}]},
         M:from_template("<el attr='{{val}}'/>",
                         [{val, "value"}])).
+
+type_matrix_accepted(_) ->
+    M = escalus_stanza,
+    Example = #xmlel{name = <<"el">>,
+                     attrs = [{<<"attr">>, <<"value">>}]},
+    ?eq(Example, M:from_template("<el attr='{{val}}'/>", [{val, "value"}])),
+    ?eq(Example, M:from_template(<<"<el attr='{{val}}'/>">>, [{val, "value"}])),
+    ?eq(Example, M:from_template(<<"<el attr='{{val}}'/>">>, [{val, <<"value">>}])),
+    ?eq(Example, M:from_template("<el attr='{{val}}'/>", [{val, <<"value">>}])).

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -9,8 +9,7 @@
 -define(eq(E, A), ?assertEqual(E, A)).
 
 all() ->
-    [sanity_check,
-     nullary_snippet_to_xmlel,
+    [nullary_snippet_to_xmlel,
      unary_snippet_to_xmlel,
      type_matrix_accepted,
      term_as_argument,
@@ -19,9 +18,6 @@ all() ->
 %%
 %% Tests
 %%
-
-sanity_check(_) ->
-    ok.
 
 nullary_snippet_to_xmlel(_) ->
     M = escalus_stanza,

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -1,0 +1,25 @@
+-module(escalus_stanza_SUITE).
+-compile(export_all).
+
+-include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(eq(E, A), ?assertEqual(E, A)).
+
+all() ->
+    [sanity_check,
+     nullary_snippet_to_xmlel].
+
+%%
+%% Tests
+%%
+
+sanity_check(_) ->
+    ok.
+
+nullary_snippet_to_xmlel(_) ->
+    M = escalus_stanza,
+    ?eq(#xmlel{name = <<"el">>}, M:from_xml("<el/>")),
+    ?eq(#xmlel{name = <<"el">>}, M:from_xml(<<"<el/>">>)).

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -13,7 +13,8 @@ all() ->
      nullary_snippet_to_xmlel,
      unary_snippet_to_xmlel,
      type_matrix_accepted,
-     term_as_argument].
+     term_as_argument,
+     attribute_as_argument].
 
 %%
 %% Tests
@@ -49,3 +50,10 @@ term_as_argument(_) ->
     Example = #xmlel{name = <<"outer">>,
                      children = [Inner]},
     ?eq(Example, M:from_template("<outer>{{{inner}}}</outer>", [{inner, Inner}])).
+
+attribute_as_argument(_) ->
+    M = escalus_stanza,
+    Attr = {<<"name">>, <<"value">>},
+    Example = #xmlel{name = <<"el">>,
+                     attrs = [Attr]},
+    ?eq(Example, M:from_template("<el {{attr}}/>", [{attr, Attr}])).

--- a/test/escalus_stanza_SUITE.erl
+++ b/test/escalus_stanza_SUITE.erl
@@ -10,7 +10,8 @@
 
 all() ->
     [sanity_check,
-     nullary_snippet_to_xmlel].
+     nullary_snippet_to_xmlel,
+     unary_snippet_to_xmlel].
 
 %%
 %% Tests
@@ -23,3 +24,10 @@ nullary_snippet_to_xmlel(_) ->
     M = escalus_stanza,
     ?eq(#xmlel{name = <<"el">>}, M:from_xml("<el/>")),
     ?eq(#xmlel{name = <<"el">>}, M:from_xml(<<"<el/>">>)).
+
+unary_snippet_to_xmlel(_) ->
+    M = escalus_stanza,
+    ?eq(#xmlel{name = <<"el">>,
+               attrs = [{<<"attr">>, <<"value">>}]},
+        M:from_template("<el attr='{{val}}'/>",
+                        [{val, "value"}])).


### PR DESCRIPTION
This allows for convenient creation of custom stanzas inline in test suites instead of laboriously writing functional constructors and placing them in `escalus_stanza`.
Please note this might not be the fastest, performance-wise, approach to getting an `xmlterm()` so watch out for CPU churn in high-load scenarios (AMOC comes to mind).