### PR TITLE
[RFC] Deprecate old style (just numeric) resource count specs

### DIFF
--- a/src/escalus_story.erl
+++ b/src/escalus_story.erl
@@ -169,6 +169,9 @@ clients_from_resource_counts(Config, ResourceCounts = [{_, _} | _]) ->
         {_User, UserSpec} <- [lists:keyfind(User, 1, NamedSpecs)]];
 %% Old-style ResourceCounts: [2, 1]
 clients_from_resource_counts(Config, ResourceCounts) ->
+    Deprecated = io_lib:format("DEPRECATED resource counts ~p (use [{alice, 1}, ...] or similar)",
+                              [ResourceCounts]),
+    escalus_compat:complain(Deprecated),
     NamedSpecs = escalus_config:get_config(escalus_users, Config),
     [resources_per_spec(UserSpec, ResCount)
      || {{_, UserSpec}, ResCount} <- zip_shortest(NamedSpecs,


### PR DESCRIPTION
These might lead to using different than expected user specs, if a config file changes. I.e. when a user spec looks like `[1,1]` and `escalus_users` in the config file change from

```erlang
{escalus_users, [
    {alice, [
        {username, <<"alicE">>},
        {server, <<"localhost">>},
        {password, <<"makota">>}]},
    {bob, [
        {username, <<"bOb">>},
        {server, <<"localhost">>},
        {password, <<"makrolika">>}]},
    {carol, [
        {username, <<"carol">>},
        {server, <<"localhost">>},
        {password, <<"jinglebells">>},
        {transport, bosh},
        {path, <<"/http-bind">>},
        {port, 5280}]}
]}.
```

to

```erlang
{escalus_users, [
    {alice, [
        {username, <<"alicE">>},
        {server, <<"localhost">>},
        {password, <<"makota">>}]},
    {carol, [
        {username, <<"carol">>},
        {server, <<"localhost">>},
        {password, <<"jinglebells">>},
        {transport, bosh},
        {path, <<"/http-bind">>},
        {port, 5280}]}
]}.
```

When bootstrapping a new project/fork such a config modification is not uncommon.