### PR TITLE
Delegate predicates

### DIFF
--- a/src/escalus.erl
+++ b/src/escalus.erl
@@ -31,6 +31,7 @@
          story/3,
          assert/2,
          assert/3,
+         assert/4,
          assert_many/2,
          send/2,
          send_and_wait/2,
@@ -83,6 +84,7 @@ end_per_testcase(_CaseName, Config) ->
 -define(FORWARD1(M, F), F(X) -> M:F(X)).
 -define(FORWARD2(M, F), F(X, Y) -> M:F(X, Y)).
 -define(FORWARD3(M, F), F(X, Y, Z) -> M:F(X, Y, Z)).
+-define(FORWARD4(M, F), F(A, B, C, D) -> M:F(A, B, C, D)).
 
 ?FORWARD1(escalus_users, create_users).
 ?FORWARD2(escalus_users, create_users).
@@ -94,6 +96,7 @@ end_per_testcase(_CaseName, Config) ->
 
 ?FORWARD2(escalus_new_assert, assert).
 ?FORWARD3(escalus_new_assert, assert).
+?FORWARD4(escalus_new_assert, assert).
 ?FORWARD2(escalus_new_assert, assert_many).
 
 ?FORWARD2(escalus_client, send).

--- a/src/escalus_new_assert.erl
+++ b/src/escalus_new_assert.erl
@@ -47,7 +47,8 @@ assert_many(Predicates, Stanzas) ->
             escalus_utils:log_stanzas("multi-assertion failed on", Stanzas)
     end,
     assert_true(Ok and AllStanzas,
-        {assertion_failed, assert_many, AllStanzas, Predicates, Stanzas, StanzasStr}).
+        {assertion_failed, assert_many, AllStanzas, Predicates, Stanzas,
+         StanzasStr}).
 
 assert(M, PredSpec, Params, Arg) ->
     Fun = predspec_to_fun(M, PredSpec, length(Params) + 1),


### PR DESCRIPTION
this allows to define own module that contains predicates, for example for testing custom features or things not implemented yet at escalus. eg

```erlang
my_test(Config) ->
  %% ...
  escalus:assert(?MODULE, is_pubsub_subscription, [<<"subscribed">>], Result)
  end.

is_pubsub_subscription(Type, Stanza) ->
  %% ... check stuff
  true.
```