### PR TITLE
Cleanup output for Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,22 @@
 all: compile
 
 compile: rebar
-	./rebar get-deps compile
+	@./rebar get-deps compile > $@.log 2>&1 \
+		|| (echo "$@ failed"; cat $@.log; exit 1)
 
 test: rebar compile
-	./rebar skip_deps=true eunit
+	@./rebar skip_deps=true eunit > $@.log 2>&1 \
+		&& (printf "%s: " $@; tail -1 $@.log) \
+		|| (echo "$@ failed"; cat $@.log; exit 2)
 
 clean: rebar
-	./rebar clean
+	@./rebar clean
 
 # Usage: make ct SUITE=user_db_module_SUITE
-#
 ct:	compile logs
-	./run_ct SUITE=$(SUITE)
+	@./run_ct SUITE=$(SUITE) > $@.log 2>&1 \
+		&& grep "TEST COMPLETE" $@.log \
+		|| (cat $@.log; exit 3)
 
 logs:
 	mkdir -p logs
@@ -64,15 +68,19 @@ MIM := deps/mongooseim
 MIM_REL := ${MIM}/rel/mongooseim
 
 mongooseim-start: ${MIM_REL}
-	${MIM_REL}/bin/mongooseimctl start && ${MIM_REL}/bin/mongooseimctl started
+	@${MIM_REL}/bin/mongooseimctl start && ${MIM_REL}/bin/mongooseimctl started \
+		|| (echo "$@ failed"; exit 4)
 
 mongooseim-stop: ${MIM_REL}
-	${MIM_REL}/bin/mongooseimctl stop && ${MIM_REL}/bin/mongooseimctl stopped > /dev/null
+	@${MIM_REL}/bin/mongooseimctl stop && ${MIM_REL}/bin/mongooseimctl stopped > /dev/null 2>&1 \
+		|| (echo "$@ failed"; exit 5)
 
 extra-deps: ${MIM}
 
 ${MIM_REL}: ${MIM}
-	cd ${MIM} && make rel
+	@cd ${MIM} && make rel > rel.log 2>&1 \
+		|| (echo "generating MongooseIM release failed"; cat rel.log; exit 6)
 
 ${MIM}:
-	ESCALUS_EXTRA_DEPS=mongooseim ./rebar get-deps
+	@ESCALUS_EXTRA_DEPS=mongooseim ./rebar get-deps > mim.log 2>&1 \
+		|| (echo "building MongooseIM failed"; cat mim.log; exit 7)

--- a/run_ct
+++ b/run_ct
@@ -5,4 +5,4 @@ if [ -n "$SUITE" ]
 then SUITE_CMD="-suite $SUITE"
 fi
 
-ct_run -config test/test.config -logdir logs -dir test $SUITE_CMD -erl_args -pa $PWD/ebin $PWD/deps/*/ebin
+ct_run -noinput -noshell -config test/test.config -logdir logs -dir test $SUITE_CMD -erl_args -pa $PWD/ebin $PWD/deps/*/ebin


### PR DESCRIPTION
The intention is to only print logs if something failed. If everything is OK, then according to the old UNIX principle - "no news is good news". Even if we print something, we print for the particular step that failed, not every line generated by the whole build process.

If this works nicely, I'm doing the same for MongooseIM which has a Travis build log of 10k (yes! 10 thousand) lines. This results in Travis being sluggish to the extent of unusability and makes searching for actual failures hard.