### PR TITLE
Simplify escalus_users:create_users API

### DIFF
--- a/elvis.config
+++ b/elvis.config
@@ -17,7 +17,7 @@
                   {elvis_style, nesting_level, #{level => 3}},
                   {elvis_style, god_modules, #{limit => 25}},
                   {elvis_style, no_if_expression},
-                  {elvis_style, invalid_dynamic_call, #{ignore => []}},
+                  {elvis_style, invalid_dynamic_call, #{ignore => [escalus_users]}},
                   {elvis_style, used_ignored_variable},
                   {elvis_style, no_behavior_info},
                   {elvis_style, state_record_and_type},

--- a/src/escalus.erl
+++ b/src/escalus.erl
@@ -26,6 +26,7 @@
          create_users/2,
          delete_users/1,
          delete_users/2,
+         get_users/1,
          override/3,
          make_everyone_friends/1,
          story/3,
@@ -88,6 +89,8 @@ end_per_testcase(_CaseName, Config) ->
 ?FORWARD2(escalus_users, create_users).
 ?FORWARD1(escalus_users, delete_users).
 ?FORWARD2(escalus_users, delete_users).
+
+?FORWARD1(escalus_users, get_users).
 
 ?FORWARD1(escalus_story, make_everyone_friends).
 ?FORWARD3(escalus_story, story).

--- a/src/escalus_ejabberd.erl
+++ b/src/escalus_ejabberd.erl
@@ -44,6 +44,8 @@
          setup_option/2,
          reset_option/2]).
 
+-type user_spec() :: escalus_users:user_spec().
+
 -include("escalus.hrl").
 
 %%%
@@ -207,19 +209,15 @@ reset_option({Option, _, Set, _}, Config) ->
 start(_) -> ok.
 stop(_) -> ok.
 
--spec create_users(escalus:config(), escalus_users:who()) -> escalus:config().
-create_users(Config, Who)
-  when is_atom(Who); is_tuple(Who) ->
-    Users = escalus_users:get_users(Who),
+-spec create_users(escalus:config(), [user_spec()]) -> escalus:config().
+create_users(Config, Users) ->
     lists:foreach(fun({_Name, UserSpec}) ->
                           register_user(Config, UserSpec)
                   end, Users),
     lists:keystore(escalus_users, 1, Config, {escalus_users, Users}).
 
--spec delete_users(escalus:config(), escalus_users:who()) -> escalus:config().
-delete_users(Config, Who)
-  when is_atom(Who); is_tuple(Who) ->
-    Users = escalus_users:get_users(Who),
+-spec delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+delete_users(Config, Users) ->
     lists:foreach(fun({_Name, UserSpec}) ->
                           unregister_user(Config, UserSpec)
                   end, Users),

--- a/src/escalus_user_db.erl
+++ b/src/escalus_user_db.erl
@@ -4,7 +4,9 @@
 %% For another implementation see ESL internal repository at
 %% https://gitlab.erlang-solutions.com/simon.zelazny/fake-auth-server.
 
+-type user_spec() :: escalus_users:user_spec().
+
 -callback start(any()) -> any().
 -callback stop(any()) -> any().
--callback create_users(escalus:config(), escalus_users:who()) -> escalus:config().
--callback delete_users(escalus:config(), escalus_users:who()) -> escalus:config().
+-callback create_users(escalus:config(), [user_spec()]) -> escalus:config().
+-callback delete_users(escalus:config(), [user_spec()]) -> escalus:config().

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -48,17 +48,15 @@
 
 %% Public types
 -export_type([user_name/0,
-              user_spec/0,
-              who/0]).
+              user_spec/0]).
 
 %% Public types
--type who() :: all | {by_name, [escalus_config:key()]}.
+-type user_name() :: atom().
 -type user_spec() :: [{user_option(), any()}].
 
 %% Internal types
 -type user() :: user_name() | user_spec().
 -type named_user() :: {user_name(), user_spec()}.
--type user_name() :: atom().
 -type host() :: inet:hostname() | inet:ip4_address() | binary().
 -type xmpp_domain() :: inet:hostname() | binary().
 
@@ -87,30 +85,28 @@ stop(Config) ->
             ok
     end.
 
--spec create_users(escalus:config(), who()) -> escalus:config().
-create_users(Config, Who) ->
+-spec create_users(escalus:config(), [user_spec()]) -> escalus:config().
+create_users(Config, Users) ->
     case auth_type(Config) of
         {escalus_user_db, xmpp} ->
-            create_users_via_xmpp(Config, Who);
+            create_users_via_xmpp(Config, Users);
         {escalus_user_db, {module, M, _}} ->
-            M:create_users(Config, Who)
+            M:create_users(Config, Users)
     end.
 
--spec create_users_via_xmpp(escalus:config(), who()) -> escalus:config().
-create_users_via_xmpp(Config, Who) ->
-    Users = get_users(Who),
+-spec create_users_via_xmpp(escalus:config(), [user_spec()]) -> escalus:config().
+create_users_via_xmpp(Config, Users) ->
     CreationResults = [create_user(Config, User) || User <- Users],
     lists:foreach(fun verify_creation/1, CreationResults),
     lists:keystore(escalus_users, 1, Config, {escalus_users, Users}).
 
--spec delete_users(escalus:config(), who()) -> escalus:config().
-delete_users(Config, Who) ->
+-spec delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+delete_users(Config, Users) ->
     case auth_type(Config) of
         {escalus_user_db, xmpp} ->
-            Users = get_users(Who),
             [delete_user(Config, User) || User <- Users];
         {escalus_user_db, {module, M, _}} ->
-            M:delete_users(Config, Who)
+            M:delete_users(Config, Users)
     end.
 
 %%--------------------------------------------------------------------
@@ -119,11 +115,11 @@ delete_users(Config, Who) ->
 
 -spec create_users(escalus:config()) -> escalus:config().
 create_users(Config) ->
-    create_users(Config, all).
+    create_users(Config, get_users(all)).
 
 -spec delete_users(escalus:config()) -> escalus:config().
 delete_users(Config) ->
-    delete_users(Config, all).
+    delete_users(Config, get_users(all)).
 
 -spec get_jid(escalus:config(), user()) -> binary().
 get_jid(Config, User) ->

--- a/test/regressions_SUITE.erl
+++ b/test/regressions_SUITE.erl
@@ -42,7 +42,7 @@ end_per_testcase(CaseName, Config) ->
 
 catch_timeout_when_waiting_for_stanza(Config) ->
     %% given
-    escalus:create_users(Config, {by_name, [alice]}),
+    escalus:create_users(Config, escalus:get_users([alice])),
     story(Config, [{alice,1}],
           fun (Alice) ->
                   %% when
@@ -51,7 +51,7 @@ catch_timeout_when_waiting_for_stanza(Config) ->
                   ?a(is_2_tuple(ErrorReason)),
                   ?eq(timeout_when_waiting_for_stanza, element(1, ErrorReason))
           end),
-    escalus:delete_users(Config, {by_name, [alice]}).
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 catch_escalus_compat_bin_badarg(_) ->
     %% when
@@ -86,7 +86,7 @@ catch_escalus_user_verify_creation(_) ->
     ?eq(my_error, element(1, ErrorReason)).
 
 test_peek_stanzas(Config) ->
-    escalus:create_users(Config, {by_name, [alice]}),
+    escalus:create_users(Config, escalus:get_users([alice])),
     story(Config, [{alice, 1}],
           fun (Alice) ->
                   %% given
@@ -99,7 +99,7 @@ test_peek_stanzas(Config) ->
                   ?a(Peeked /= []),
                   ?a(actually_has_stanzas(Peeked))
           end),
-    escalus:delete_users(Config, {by_name, [alice]}).
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/test/regressions_SUITE.erl
+++ b/test/regressions_SUITE.erl
@@ -43,7 +43,7 @@ end_per_testcase(CaseName, Config) ->
 catch_timeout_when_waiting_for_stanza(Config) ->
     %% given
     escalus:create_users(Config, escalus:get_users([alice])),
-    story(Config, [{alice,1}],
+    story(Config, [{alice, 1}],
           fun (Alice) ->
                   %% when
                   {'EXIT', ErrorReason} = (catch escalus:wait_for_stanza(Alice)),


### PR DESCRIPTION
Now `escalus_users:create_users/2` just expects a list of `user_spec()` instances. This is simpler to remember and doesn't require as many "trying to be smart" hacks in the library. See description of 62f2832 for what it means in practice.