### PR TITLE
add jid to client record in escalus_connection:start

### DIFF
--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -51,9 +51,8 @@ start(Config, UserSpec, Resource) ->
     EventClient = escalus_event:new_client(Config, UserSpec, Resource),
     Options = escalus_users:get_options(Config, UserSpec, Resource, EventClient),
     case escalus_connection:start(Options) of
-        {ok, Conn, Props, _} ->
-            Jid = make_jid(Props),
-            Client = Conn#client{jid = Jid, event_client = EventClient},
+        {ok, Conn, _Props, _} ->
+            Client = Conn#client{event_client = EventClient},
             escalus_cleaner:add_client(Config, Client),
             {ok, Client};
         {error, Error} ->
@@ -143,19 +142,12 @@ username(Client) ->
 server(Client) ->
     escalus_utils:regexp_get(full_jid(Client), <<"^[^@]*[@]([^/]*)">>).
 
+-spec resource(esclus:client()) -> binary().
 resource(Client) ->
-    escalus_utils:regexp_get(full_jid(Client), <<"^[^/]*[/](.*)">>).
-
+    escalus_utils:get_resource(full_jid(Client)).
 %%--------------------------------------------------------------------
 %% helpers
 %%--------------------------------------------------------------------
-
-make_jid(Proplist) ->
-    {username, U} = lists:keyfind(username, 1, Proplist),
-    {server, S} = lists:keyfind(server, 1, Proplist),
-    {resource, R} = lists:keyfind(resource, 1, Proplist),
-    <<U/binary,"@",S/binary,"/",R/binary>>.
-
 
 %% #client{} record for transport is created before assigning client JID
 %% so when we match a Client with it, Client#client.jid needs to be undefined

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -106,7 +106,9 @@ start(Props0, Steps) ->
                                                 {Conn, Props, []},
                                                 [prepare_step(Step)
                                                  || Step <- Steps]),
-        {ok, Conn1, Props1, Features}
+        Jid = escalus_utils:make_jid(Props1),
+        Client = Conn1#client{jid = Jid},
+        {ok, Client, Props1, Features}
     catch
         throw:{connection_step_failed, _Details, _Reason} = Error ->
             {error, Error}

--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -105,13 +105,15 @@ bind(Conn, Props) ->
     escalus:assert(is_iq_result, BindReply),
     ?NS_BIND = exml_query:path(BindReply, [{element, <<"bind">>},
                                            {attr, <<"xmlns">>}]),
+    JID = exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]),
+    Resource = escalus_utils:get_resource(JID),
+    PropsWithRes = lists:keystore(resource, 1, Props, {resource, Resource}),
     case proplists:get_value(auth_method, Props) of
         <<"SASL-ANON">> ->
-            JID = exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]),
             TMPUsername = escalus_utils:get_username(JID),
-            lists:keyreplace(username, 1, Props, {username, TMPUsername});
+            lists:keyreplace(username, 1, PropsWithRes, {username, TMPUsername});
         _ ->
-            Props
+            PropsWithRes
     end.
 
 -spec compress(client(), user_spec()) -> {client(), user_spec()}.

--- a/src/escalus_utils.erl
+++ b/src/escalus_utils.erl
@@ -26,7 +26,9 @@
          identity/1,
          mix_match/3,
          get_jid/1,
+         make_jid/1,
          get_short_jid/1,
+         get_resource/1,
          jid_to_lower/1,
          get_username/1,
          get_server/1,
@@ -141,7 +143,15 @@ get_jid(Jid) when is_list(Jid) ->
 get_jid(Jid) when is_binary(Jid) ->
     Jid.
 
--spec get_short_jid(#client{} | atom() | binary() | string()) -> binary().
+-spec make_jid(escalus_users:user_spec()) -> binary().
+make_jid(Proplist) ->
+    {username, U} = lists:keyfind(username, 1, Proplist),
+    {server, S} = lists:keyfind(server, 1, Proplist),
+    {resource, R} = lists:keyfind(resource, 1, Proplist),
+    <<U/binary, "@", S/binary, "/", R/binary>>.
+
+
+-spec get_short_jid(escalus:client() | atom() | binary() | string()) -> binary().
 get_short_jid(#client{}=Recipient) ->
     escalus_client:short_jid(Recipient);
 get_short_jid(Username) when is_atom(Username) ->
@@ -150,6 +160,10 @@ get_short_jid(Jid) when is_list(Jid) ->
     list_to_binary(Jid);
 get_short_jid(Jid) when is_binary(Jid) ->
     Jid.
+
+get_resource(FullJID) ->
+    escalus_utils:regexp_get(FullJID, <<"^[^/]*[/](.*)">>).
+
 
 -spec jid_to_lower(binary()) -> binary().
 jid_to_lower(Jid) ->


### PR DESCRIPTION
There are situation where we use only `escalus_connection` api to get the user connected to the server. In this case, before the fix the jid field of `#client` record was not set by `escalus_conneciton` but by `escalus_client`.
