### PR TITLE
Fix crash connecting to Hipchat XMPP endpoint

### DIFF
--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -348,4 +348,5 @@ mechanism_to_auth_function(<<"DIGEST-MD5">>)  -> auth_digest_md5;
 mechanism_to_auth_function(<<"ANONYMOUS">>)   -> auth_anonymous;
 mechanism_to_auth_function(<<"EXTERNAL">>)    -> auth_sasl_external;
 mechanism_to_auth_function(<<"SCRAM-SHA-1">>) -> auth_sasl_scram_sha1;
-mechanism_to_auth_function(<<"X-OAUTH">>)     -> auth_sasl_oauth.
+mechanism_to_auth_function(<<"X-OAUTH">>)     -> auth_sasl_oauth;
+mechanism_to_auth_function(_)                 -> auth_unknown.


### PR DESCRIPTION
Hi, 

I'm working for sameroom.io and we are using escalus to connect to Hipchat. It seems last additions break it, as it uses non-standard SASL mechanism - X-HIPCHAT-OAUTH2. This simple change fixes issue for us. See https://docs.atlassian.com/hipchat.xmpp/latest/xmpp/auth.html for more info.
Would be great to have it in the main repo, so we don't need to use our fork.

Thanks,
Mikl