### PR TITLE
Remove deprecated transport detection

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -141,8 +141,7 @@ connect(Props) ->
     Server = proplists:get_value(server, Props, <<"localhost">>),
     Host = proplists:get_value(host, Props, Server),
     NewProps = lists:keystore(host, 1, Props, {host, Host}),
-    Mod = get_module(Transport),
-    {ok, Conn} = Mod:connect(NewProps),
+    {ok, Conn} = Transport:connect(NewProps),
     {ok, Conn, NewProps}.
 
 send(#client{module = Mod, event_client = EventClient, jid = Jid} = Client, Elem) ->
@@ -215,32 +214,6 @@ maybe_forward_to_owner(_, State, Stanzas, Fun) ->
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
-
-%% TODO: drop
-get_module_old(tcp) -> escalus_tcp;
-get_module_old(ws) -> escalus_ws;
-get_module_old(bosh) -> escalus_bosh.
-
-%% TODO: drop
-is_deprecated_connection_module(M) when M == tcp; M == ws; M == bosh -> true;
-is_deprecated_connection_module(_) -> false.
-
--spec get_module(module() | atom()) -> ?MODULE:t().
-get_module(M) when is_atom(M) ->
-    case is_deprecated_connection_module(M) of
-        true ->
-            %% This function is a natural extension point - we could extend Escalus freely
-            %% by providing modules that implement escalus_connection behaviour.
-            %% However, due to this mapping (predefined atom -> module name)
-            %% we limit this flexibility.
-            %% TODO: Let's remove this limitation in the future.
-            Msg = io_lib:format("~s:get_module/1 called with transport '~s' "
-                                "(use a module name instead)", [?MODULE, M]),
-            escalus_compat:complain(Msg),
-            get_module_old(M);
-        false ->
-            M
-    end.
 
 get_connection_steps(UserSpec) ->
     case lists:keyfind(connection_steps, 1, UserSpec) of

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -5,7 +5,6 @@
 %%%===================================================================
 -module(escalus_connection).
 
--include_lib("exml/include/exml_stream.hrl").
 -include("escalus.hrl").
 
 %% High-level API
@@ -34,7 +33,7 @@
 -type step_spec() :: atom() | {module(), atom()} | escalus_session:step().
 -export_type([step_spec/0]).
 
--type filter_pred() :: fun((#xmlel{}) -> boolean()) | none.
+-type filter_pred() :: fun((exml:element()) -> boolean()) | none.
 -export_type([filter_pred/0]).
 
 -export_type([t/0]).
@@ -54,7 +53,7 @@
 -type t() :: module().
 
 -callback connect([proplists:property()]) -> {ok, client()}.
--callback send(client(), #xmlel{}) -> no_return().
+-callback send(client(), exml:element()) -> ok.
 -callback stop(client()) -> ok | already_stopped.
 
 -callback is_connected(client()) -> boolean().
@@ -144,6 +143,7 @@ connect(Props) ->
     {ok, Conn} = Transport:connect(NewProps),
     {ok, Conn, NewProps}.
 
+-spec send(escalus:client(), exml:element()) -> ok.
 send(#client{module = Mod, event_client = EventClient, jid = Jid} = Client, Elem) ->
     escalus_event:outgoing_stanza(EventClient, Elem),
     escalus_ct:log_stanza(Jid, out, Elem),
@@ -193,8 +193,8 @@ kill(#client{module = Mod} = Client) ->
     Mod:kill(Client).
 
 
--spec maybe_forward_to_owner(filter_pred(), term(), [#xmlel{}],
-                             fun(([#xmlel{}], term()) -> term()))
+-spec maybe_forward_to_owner(filter_pred(), term(), [exml:element()],
+                             fun(([exml:element()], term()) -> term()))
         -> term().
 maybe_forward_to_owner(none, State, _Stanzas, _Fun) ->
     State;

--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -67,7 +67,7 @@ start_stream(Conn, Props) ->
     Transport = proplists:get_value(transport, Props, tcp),
     IsLegacy = proplists:get_value(wslegacy, Props, false),
     StreamStartReq = case {Transport, IsLegacy} of
-                         {ws, false} -> escalus_stanza:ws_open(Server);
+                         {escalus_ws, false} -> escalus_stanza:ws_open(Server);
                          _ -> escalus_stanza:stream_start(Server, NS)
                      end,
     ok = escalus_connection:send(Conn, StreamStartReq),
@@ -265,12 +265,12 @@ session(Conn, Props, Features) ->
 
 assert_stream_start(StreamStartRep, Transport, IsLegacy) ->
     case {StreamStartRep, Transport, IsLegacy} of
-        {#xmlel{name = <<"open">>}, ws, false} ->
+        {#xmlel{name = <<"open">>}, escalus_ws, false} ->
             ok;
-        {#xmlel{name = <<"open">>}, ws, true} ->
+        {#xmlel{name = <<"open">>}, escalus_ws, true} ->
             error("<open/> with legacy WebSocket",
                   [StreamStartRep]);
-        {#xmlstreamstart{}, ws, false} ->
+        {#xmlstreamstart{}, escalus_ws, false} ->
             error("<stream:stream> with non-legacy WebSocket",
                   [StreamStartRep]);
         {#xmlstreamstart{}, _, _} ->
@@ -281,11 +281,11 @@ assert_stream_start(StreamStartRep, Transport, IsLegacy) ->
 
 assert_stream_features(StreamFeatures, Transport, IsLegacy) ->
     case {StreamFeatures, Transport, IsLegacy} of
-        {#xmlel{name = <<"features">>}, ws, false} ->
+        {#xmlel{name = <<"features">>}, escalus_ws, false} ->
             ok;
-        {#xmlel{name = <<"features">>}, ws, true} ->
+        {#xmlel{name = <<"features">>}, escalus_ws, true} ->
             error("<features> with legacy WebSocket");
-        {#xmlel{name = <<"stream:features">>}, ws, false} ->
+        {#xmlel{name = <<"stream:features">>}, escalus_ws, false} ->
             error("<stream:features> with non-legacy WebSocket",
                   [StreamFeatures]);
         {#xmlel{name = <<"stream:features">>}, _, _} ->


### PR DESCRIPTION
With this PR it is possible to define the transport (TCP, BOSH, WebSockets) by specifying the whole module implementing given transport.
This PR breaks backward compatibility.

Goes on top of #118