### PR TITLE
Add server caps to stream features

### DIFF
--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -305,7 +305,8 @@ get_stream_features(Features) ->
      {stream_management, get_stream_management(Features)},
      {advanced_message_processing, get_advanced_message_processing(Features)},
      {client_state_indication, get_client_state_indication(Features)},
-     {sasl_mechanisms, get_sasl_mechanisms(Features)}].
+     {sasl_mechanisms, get_sasl_mechanisms(Features)},
+     {caps, get_server_caps(Features)}].
 
 -spec get_compression(exml:element()) -> boolean().
 get_compression(Features) ->
@@ -335,6 +336,16 @@ get_client_state_indication(Features) ->
 get_sasl_mechanisms(Features) ->
     exml_query:paths(Features, [{element, <<"mechanisms">>},
                                 {element, <<"mechanism">>}, cdata]).
+
+-spec get_server_caps(exml:element()) -> map().
+get_server_caps(Features) ->
+    case exml_query:subelement(Features, <<"c">>) of
+        #xmlel{attrs = Attrs} ->
+            maps:from_list(Attrs);
+        _ ->
+            undefined
+    end.
+
 
 -spec stream_start_to_element(exml_stream:start() | exml:element()) -> exml:element().
 stream_start_to_element(#xmlel{name = <<"open">>} = Open) -> Open;

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -304,12 +304,14 @@ is_mod_register_enabled(Config) ->
                                                  stream_features,
                                                  maybe_use_ssl]),
     escalus_connection:send(Conn, escalus_stanza:get_registration_fields()),
-    case wait_for_result(Conn) of
-        {error, _, _} ->
-            false;
-        _ ->
-            true
-    end.
+    Result = case wait_for_result(Conn) of
+                 {error, _, _} ->
+                     false;
+                 _ ->
+                     true
+             end,
+    escalus_connection:stop(Conn),
+    Result.
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
This is for esl/MongooseIM#1009

Also this PR modifies the 'is_mod_register_enabled` function. Now the temporary XMPP session, used to check if in-band registration is possible, is closed.