### PR TITLE
Add try clause matching normal exit

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -95,6 +95,8 @@ stop(#client{rcv_pid = Pid}) ->
         gen_server:call(Pid, stop)
     catch
         exit:{noproc, {gen_server, call, _}} ->
+            already_stopped;
+        exit:{normal, {gen_server, call, _}} ->
             already_stopped
     end.
 

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -86,6 +86,8 @@ stop(#client{rcv_pid = Pid}) ->
         gen_server:call(Pid, stop)
     catch
         exit:{noproc, {gen_server, call, _}} ->
+            already_stopped;
+        exit:{normal, {gen_server, call, _}} ->
             already_stopped
     end.
 

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -64,6 +64,8 @@ stop(#client{rcv_pid = Pid}) ->
         gen_server:call(Pid, stop)
     catch
         exit:{noproc, {gen_server, call, _}} ->
+            already_stopped;
+        exit:{normal, {gen_server, call, _}} ->
             already_stopped
     end.
 


### PR DESCRIPTION
It is possible that the gen_server will be called while it's
still stopping but not yet stopped.
In this case the following exit signal is sent:
```erlang
{normal, {gen_server, call, _}}
```