### PR TITLE
Implement bind 2.0

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -101,10 +101,10 @@ start(Props) ->
 start(Props0, Steps) ->
     try
         {ok, Conn, Props} = connect(Props0),
+        PreparedSteps = [prepare_step(Step) || Step <- Steps],
         {Conn1, Props1, Features} = lists:foldl(fun connection_step/2,
                                                 {Conn, Props, []},
-                                                [prepare_step(Step)
-                                                 || Step <- Steps]),
+                                                PreparedSteps),
         {ok, Conn1, Props1, Features}
     catch
         throw:{connection_step_failed, _Details, _Reason} = Error ->

--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -8,7 +8,6 @@
 -export([start_stream/2,
          authenticate/2,
          starttls/2,
-         bind/2,
          compress/2,
          use_ssl/2,
          can_use_amp/2,
@@ -54,6 +53,7 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 -include("escalus_xmlns.hrl").
+-include("escalus.hrl").
 -define(DEFAULT_RESOURCE, <<"escalus-default-resource">>).
 
 %%%===================================================================
@@ -94,30 +94,6 @@ authenticate(Conn, Props) ->
     {Props1, []} = escalus_session:start_stream(Conn, PropsAfterAuth),
     escalus_session:stream_features(Conn, Props1, []),
     Props1.
-
--spec bind(client(), user_spec()) -> user_spec().
-bind(Conn, Props) ->
-    Resource = proplists:get_value(resource, Props, ?DEFAULT_RESOURCE),
-    BindStanza = escalus_stanza:bind(Resource),
-
-    escalus_connection:send(Conn, BindStanza),
-    BindReply = escalus_connection:get_stanza(Conn, bind_reply),
-    escalus:assert(is_bind_result, BindReply),
-
-    JID = exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]),
-    PropsWithResource =
-        case is_binary(JID) of
-            true -> lists:keystore(resource, 1, Props, {resource, escalus_utils:get_resource(JID)});
-            false -> Props
-        end,
-
-    case proplists:get_value(auth_method, Props) of
-        <<"SASL-ANON">> ->
-            TMPUsername = escalus_utils:get_username(JID),
-            lists:keyreplace(username, 1, PropsWithResource, {username, TMPUsername});
-        _ ->
-            PropsWithResource
-    end.
 
 -spec compress(client(), user_spec()) -> {client(), user_spec()}.
 compress(Conn, Props) ->
@@ -262,7 +238,27 @@ authenticate(Conn, Props, Features) ->
 
 -spec ?CONNECTION_STEP_SIG(bind).
 bind(Conn, Props, Features) ->
-    {Conn, bind(Conn, Props), Features}.
+    Resource = proplists:get_value(resource, Props, ?DEFAULT_RESOURCE),
+    escalus_connection:send(Conn, escalus_stanza:bind(Resource)),
+    BindReply = escalus_connection:get_stanza(Conn, bind_reply),
+    escalus:assert(is_bind_result, BindReply),
+    JID = exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]),
+    Conn2 = Conn#client{jid = JID},
+
+	PropsWithResource =
+        case is_binary(JID) of
+            true -> lists:keystore(resource, 1, Props, {resource, escalus_utils:get_resource(JID)});
+            false -> Props
+        end,
+
+    Props2 = case proplists:get_value(auth_method, Props) of
+                 <<"SASL-ANON">> ->
+                     TMPUsername = escalus_utils:get_username(JID),
+                     lists:keyreplace(username, 1, PropsWithResource, {username, TMPUsername});
+                 _ ->
+                     PropsWithResource
+             end,
+    {Conn2, Props2, Features}.
 
 -spec ?CONNECTION_STEP_SIG(session).
 session(Conn, Props, Features) ->

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -113,6 +113,7 @@
 -export([iq/2, iq/3]).
 
 -export([bind/1,
+         bind_2_0/0,
          session/0]).
 
 -export([setattr/3,
@@ -214,6 +215,11 @@ bind(Resource) ->
        [#xmlel{name = <<"bind">>,
                attrs = [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-bind">>}],
                children = Children}]).
+
+-spec bind_2_0() -> exml:element().
+bind_2_0() ->
+    #xmlel{name = <<"bind">>,
+           attrs = [{<<"xmlns">>, <<"urn:xmpp:bind2:0">>}]}.
 
 -spec session() -> exml:element().
 session() ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -48,6 +48,7 @@
 
 %% Public types
 -export_type([user_name/0,
+              named_user/0,
               user_spec/0]).
 
 %% Public types

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -382,8 +382,8 @@ get_defined_option(Config, Name, Short, Long) ->
 
 -spec wait_for_result(escalus:client()) -> {ok, result, exml:element()}
                                          | {ok, conflict, exml:element()}
-                                         | {error, Error, exml:cdata()}
-      when Error :: 'failed_to_register' | 'bad_response' | 'timeout'.
+                                         | {error, Error, exml:element()}
+      when Error :: 'failed_to_register' | 'bad_response'.
 wait_for_result(Conn) ->
     Stanza = escalus:wait_for_stanza(Conn),
     case response_type(Stanza) of

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -384,20 +384,16 @@ get_defined_option(Config, Name, Short, Long) ->
                                          | {error, Error, exml:cdata()}
       when Error :: 'failed_to_register' | 'bad_response' | 'timeout'.
 wait_for_result(Conn) ->
-    receive
-        {stanza, Conn, Stanza} ->
-            case response_type(Stanza) of
-                result ->
-                    {ok, result, Stanza};
-                conflict ->
-                    {ok, conflict, Stanza};
-                error ->
-                    {error, failed_to_register, Stanza};
-                _ ->
-                    {error, bad_response, Stanza}
-            end
-    after 3000 ->
-            {error, timeout, exml:escape_cdata(<<"timeout">>)}
+    Stanza = escalus:wait_for_stanza(Conn),
+    case response_type(Stanza) of
+        result ->
+            {ok, result, Stanza};
+        conflict ->
+            {ok, conflict, Stanza};
+        error ->
+            {error, failed_to_register, Stanza};
+        _ ->
+            {error, bad_response, Stanza}
     end.
 
 response_type(#xmlel{name = <<"iq">>} = IQ) ->

--- a/test/escalus_fresh_SUITE.erl
+++ b/test/escalus_fresh_SUITE.erl
@@ -49,7 +49,7 @@ fresh_users_can_be_created_outside_a_story(_) ->
     given_escalus_started(C),
 
     % when
-    escalus_fresh:create_users(C, [{ada, 1}]),
+    escalus_fresh:create_users(C, [ada]),
 
     % then
     [{Suffix,


### PR DESCRIPTION
Proposed changes include:
* implementation of bind 2.0 as described in this [proto XEP](http://xmpp.org/extensions/inbox/bind2.0.html)
* removal of `escalus_session:bind/2` - it is not needed
* `escalus_session:bind/3` returns client data with jid set based on the result of bind query