### PR TITLE
Improve concurrency in escalus_bosh (+fixes)

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -564,12 +564,12 @@ detect_type(Attrs) ->
     Get = fun(A) -> proplists:get_value(A, Attrs) end,
     case {Get(<<"type">>), Get(<<"xmpp:version">>)} of
         {<<"terminate">>, _} -> streamend;
-        {_,       undefined} -> normal;
-        {_,         Version} -> {streamstart,Version}
+        {_, undefined} -> normal;
+        {_, Version} -> {streamstart, Version}
     end.
 
-host_to_list({_,_,_,_} = IP4) -> inet_parse:ntoa(IP4);
-host_to_list({_,_,_,_,_,_,_,_} = IP6) -> inet_parse:ntoa(IP6);
+host_to_list({_, _, _, _} = IP4) -> inet_parse:ntoa(IP4);
+host_to_list({_, _, _, _, _, _, _, _} = IP6) -> inet_parse:ntoa(IP6);
 host_to_list(BHost) when is_binary(BHost) -> binary_to_list(BHost);
 host_to_list(Host) when is_list(Host) -> Host.
 

--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -80,7 +80,7 @@
          }).
 
 -type state() :: #state{}.
--type async_req() :: {reference(), fun(() -> any())}.
+-type async_req() :: {Ref :: reference(), Rid :: integer(), ReqFun :: fun(() -> any())}.
 
 %%%===================================================================
 %%% API
@@ -168,7 +168,7 @@ session_creation_body(_Wait, _Version, Lang, Rid, To, Sid) ->
                  {<<"to">>, To},
                  {<<"xmpp:restart">>, <<"true">>}]).
 
--spec session_termination_body(Rid :: integer(), Sid :: binary()) -> exml:element().
+-spec session_termination_body(Rid :: integer(), Sid :: binary() | nil) -> exml:element().
 session_termination_body(Rid, Sid) ->
     Body = empty_body(Rid, Sid, [{<<"type">>, <<"terminate">>}]),
     Body#xmlel{children = [escalus_stanza:presence(<<"unavailable">>)]}.
@@ -177,7 +177,8 @@ session_termination_body(Rid, Sid) ->
 empty_body(Rid, Sid) ->
     empty_body(Rid, Sid, []).
 
--spec empty_body(Rid :: integer(), Sid :: binary(), ExtraAttrs :: [exml:attr()]) -> exml:element().
+-spec empty_body(Rid :: integer(), Sid :: binary() | nil, ExtraAttrs :: [exml:attr()]) ->
+    exml:element().
 empty_body(Rid, Sid, ExtraAttrs) ->
     #xmlel{name = <<"body">>,
            attrs = common_attrs(Rid, Sid) ++ ExtraAttrs}.

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -48,7 +48,8 @@
 
 %% Public types
 -export_type([user_name/0,
-              user_spec/0]).
+              user_spec/0,
+              named_user/0]).
 
 %% Public types
 -type user_name() :: atom().


### PR DESCRIPTION
This PR improves BOSH interleaving support in `escalus_bosh`. It ensures message order and tracks requests better.