### PR TITLE
Clean up connection management

### DIFF
--- a/include/escalus.hrl
+++ b/include/escalus.hrl
@@ -23,10 +23,7 @@
 -record(client, {
         jid :: binary() | undefined,
         module :: atom(),
-        socket :: term(),
-        ssl :: boolean(),
-        compress :: {zlib, {Zin::zlib:zstream(), Zout::zlib:zstream()}}
-                 |  false,
         rcv_pid :: pid(),
-        event_client :: any()
+        event_client :: any(),
+        props :: list()
        }).

--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -17,12 +17,15 @@
          send/2,
          is_connected/1,
          upgrade_to_tls/2,
-         use_zlib/2,
-         get_transport/1,
+         use_zlib/1,
          reset_parser/1,
          stop/1,
          kill/1,
-         set_filter_predicate/2]).
+         set_filter_predicate/2,
+         stream_start_req/1,
+         stream_end_req/1,
+         assert_stream_start/2,
+         assert_stream_end/2]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -86,26 +89,25 @@
 %%% API
 %%%===================================================================
 
--spec connect([{atom(), any()}]) -> {ok, escalus:client()}.
+-spec connect([{atom(), any()}]) -> pid().
 connect(Args) ->
     {ok, Pid} = gen_server:start_link(?MODULE, [Args, self()], []),
-    Transport = gen_server:call(Pid, get_transport),
-    {ok, Transport}.
+    Pid.
 
--spec send(escalus:client(), exml:element()) -> ok.
-send(#client{rcv_pid = Pid} = Socket, Elem) ->
-    gen_server:call(Pid, {send, Socket, Elem}).
+-spec send(pid(), exml:element()) -> ok.
+send(Pid, Elem) ->
+    gen_server:call(Pid, {send, Elem}).
 
--spec is_connected(escalus:client()) -> boolean().
-is_connected(#client{rcv_pid = Pid}) ->
+-spec is_connected(pid()) -> boolean().
+is_connected(Pid) ->
     erlang:is_process_alive(Pid).
 
--spec reset_parser(escalus:client()) -> ok.
-reset_parser(#client{rcv_pid = Pid}) ->
+-spec reset_parser(pid()) -> ok.
+reset_parser(Pid) ->
     gen_server:cast(Pid, reset_parser).
 
--spec stop(escalus:client()) -> ok | already_stopped.
-stop(#client{rcv_pid = Pid}) ->
+-spec stop(pid()) -> ok | already_stopped.
+stop(Pid) ->
     try
         gen_server:call(Pid, stop)
     catch
@@ -118,27 +120,40 @@ stop(#client{rcv_pid = Pid}) ->
                    process_info(Pid, messages), catch sys:get_state(Pid)})
     end.
 
--spec kill(escalus:client()) -> ok.
-kill(#client{} = Client) ->
-    mark_as_terminated(Client),
-    stop(Client).
+-spec kill(pid()) -> ok | already_stopped.
+kill(Pid) ->
+    mark_as_terminated(Pid),
+    stop(Pid).
 
--spec upgrade_to_tls(escalus:client(), list()) -> not_supported.
-upgrade_to_tls(#client{} = _Conn, _Props) ->
-    not_supported.
+-spec upgrade_to_tls(_, _) -> no_return().
+upgrade_to_tls(_, _) ->
+    error(not_supported).
 
--spec use_zlib(escalus:client(), list()) -> not_supported.
-use_zlib(#client{} = _Conn, _Props) ->
-    not_supported.
+-spec use_zlib(pid()) -> no_return().
+use_zlib(_Pid) ->
+    error(not_supported).
 
--spec get_transport(escalus:client()) -> escalus:client().
-get_transport(#client{rcv_pid = Pid}) ->
-    gen_server:call(Pid, get_transport).
-
--spec set_filter_predicate(escalus_connection:client(),
-    escalus_connection:filter_pred()) -> ok.
-set_filter_predicate(#client{rcv_pid = Pid}, Pred) ->
+-spec set_filter_predicate(pid(), escalus_connection:filter_pred()) -> ok.
+set_filter_predicate(Pid, Pred) ->
     gen_server:call(Pid, {set_filter_pred, Pred}).
+
+-spec stream_start_req(escalus_users:user_spec()) -> exml_stream:element().
+stream_start_req(Props) ->
+    {server, Server} = lists:keyfind(server, 1, Props),
+    NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
+    escalus_stanza:stream_start(Server, NS).
+
+-spec stream_end_req(_) -> exml_stream:element().
+stream_end_req(_) ->
+    escalus_stanza:stream_end().
+
+-spec assert_stream_start(exml_stream:element(), _) -> exml_stream:element().
+assert_stream_start(Rep = #xmlstreamstart{}, _) -> Rep;
+assert_stream_start(Rep, _) -> error("Not a valid stream start", [Rep]).
+
+-spec assert_stream_end(exml_stream:element(), _) -> exml_stream:element().
+assert_stream_end(Rep = #xmlstreamend{}, _) -> Rep;
+assert_stream_end(Rep, _) -> error("Not a valid stream end", [Rep]).
 
 %%%===================================================================
 %%% BOSH XML elements
@@ -220,42 +235,41 @@ pack_rid(Rid) ->
 %%
 %% Otherwise, the non-matching request IDs will
 %% confuse the server and possibly cause errors.
--spec send_raw(escalus:client(), exml:element()) -> ok.
-send_raw(#client{rcv_pid = Pid} = Transport, Body) ->
-    gen_server:cast(Pid, {send_raw, Transport, Body}).
+-spec send_raw(pid(), exml:element()) -> ok.
+send_raw(Pid, Body) ->
+    gen_server:cast(Pid, {send_raw, Body}).
 
 %% This is much like send_raw/2 except for the fact that
 %% the request ID won't be autoincremented on send.
 %% I.e. it is intended for resending packets which were
 %% already sent.
--spec resend_raw(escalus:client(), exml:element()) -> ok.
-resend_raw(#client{rcv_pid = Pid} = Transport, Body) ->
-    gen_server:cast(Pid, {resend_raw, Transport, Body}).
+-spec resend_raw(pid(), exml:element()) -> ok.
+resend_raw(Pid, Body) ->
+    gen_server:cast(Pid, {resend_raw, Body}).
 
--spec get_rid(escalus:client()) -> integer() | nil.
-get_rid(#client{rcv_pid = Pid}) ->
+-spec get_rid(pid()) -> integer() | nil.
+get_rid(Pid) ->
     gen_server:call(Pid, get_rid).
 
--spec get_sid(escalus:client()) -> binary() | nil.
-get_sid(#client{rcv_pid = Pid}) ->
+-spec get_sid(pid()) -> binary() | nil.
+get_sid(Pid) ->
     gen_server:call(Pid, get_sid).
 
--spec get_keepalive(escalus:client()) -> boolean().
-get_keepalive(#client{rcv_pid = Pid}) ->
+-spec get_keepalive(pid()) -> boolean().
+get_keepalive(Pid) ->
     gen_server:call(Pid, get_keepalive).
 
--spec set_keepalive(escalus:client(), boolean()) ->
-    {ok, OldKeepalive :: boolean(), NewKeepalive :: boolean()}.
-set_keepalive(#client{rcv_pid = Pid}, NewKeepalive) ->
+-spec set_keepalive(pid(), boolean()) -> {ok, OldKeepalive :: boolean(), NewKeepalive :: boolean()}.
+set_keepalive(Pid, NewKeepalive) ->
     gen_server:call(Pid, {set_keepalive, NewKeepalive}).
 
--spec mark_as_terminated(escalus:client()) -> {ok, marked_as_terminated}.
-mark_as_terminated(#client{rcv_pid = Pid}) ->
+-spec mark_as_terminated(pid()) -> {ok, marked_as_terminated}.
+mark_as_terminated(Pid) ->
     gen_server:call(Pid, mark_as_terminated).
 
--spec pause(escalus:client(), integer()) -> ok.
-pause(#client{rcv_pid = Pid} = Transport, Seconds) ->
-    gen_server:cast(Pid, {pause, Transport, Seconds}).
+-spec pause(pid(), integer()) -> ok.
+pause(Pid, Seconds) ->
+    gen_server:cast(Pid, {pause, Seconds}).
 
 %% get_-/set_active tries to tap into the intuition gained from using
 %% inet socket option {active, true | false | once}.
@@ -266,20 +280,20 @@ pause(#client{rcv_pid = Pid} = Transport, Seconds) ->
 %%
 %% Sometimes it's necessary to intercept the whole BOSH wrapper
 %% not only the wrapped stanzas. That's when this mechanism proves useful.
--spec get_active(escalus:client()) -> boolean().
-get_active(#client{rcv_pid = Pid}) ->
+-spec get_active(pid()) -> boolean().
+get_active(Pid) ->
     gen_server:call(Pid, get_active).
 
--spec set_active(escalus:client(), boolean()) -> ok.
-set_active(#client{rcv_pid = Pid}, Active) ->
+-spec set_active(pid(), boolean()) -> ok.
+set_active(Pid, Active) ->
     gen_server:call(Pid, {set_active, Active}).
 
 -spec recv(escalus:client()) -> exml_stream:element() | empty.
-recv(#client{rcv_pid = Pid}) ->
+recv(Pid) ->
     gen_server:call(Pid, recv).
 
--spec get_requests(escalus:client()) -> non_neg_integer().
-get_requests(#client{rcv_pid = Pid}) ->
+-spec get_requests(pid()) -> non_neg_integer().
+get_requests(Pid) ->
     gen_server:call(Pid, get_requests).
 
 %% This flag makes client to fail on stream error,
@@ -328,16 +342,12 @@ init([Args, Owner]) ->
     {reply, term(), state()}
     | {noreply, state()}
     | {stop, normal, ok, state()}.
-handle_call({send, Transport, Elem}, _From, State) ->
-    NewState = wrap_and_send(Transport, Elem, State),
+handle_call({send, Elem}, _From, State) ->
+    NewState = wrap_and_send(Elem, State),
     {reply, ok, NewState};
-
-handle_call(get_transport, _From, State) ->
-    {reply, transport(State), State};
 
 handle_call(get_sid, _From, #state{sid = Sid} = State) ->
     {reply, Sid, State};
-
 handle_call(get_rid, _From, #state{rid = Rid} = State) ->
     {reply, Rid, State};
 
@@ -359,7 +369,6 @@ handle_call({set_active, Active}, _From, State) ->
 handle_call(recv, _From, State) ->
     {Reply, NS} = handle_recv(State),
     {reply, Reply, NS};
-
 handle_call(get_requests, _From, State) ->
     {reply, queue:len(State#state.requests) + queue:len(State#state.pending_requests), State};
 
@@ -372,49 +381,45 @@ handle_call({set_quickfail, QuickfailFlag}, _From, State) ->
 handle_call(stop, _From, #state{ terminated = true } = State) ->
     {stop, normal, ok, State};
 handle_call(stop, From, #state{ waiting_requesters = WaitingRequesters } = State) ->
-    StreamEnd = escalus_stanza:stream_end(),
     Ref = make_ref(),
-    NewState = wrap_and_send(transport(State), exml:to_iolist(StreamEnd), Ref, State),
+    NewState = wrap_and_send(escalus_stanza:stream_end(), Ref, State),
     {noreply, NewState#state{ waiting_requesters = [{Ref, From} | WaitingRequesters] }}.
 
 -spec handle_cast(term(), state()) -> {noreply, state()} | {stop, normal, state()}.
 handle_cast(stop, State) ->
     {stop, normal, State};
 
-handle_cast({send_raw, Transport, Body}, State) ->
-    NewState = send(Transport, Body, State),
+handle_cast({send_raw, Body}, State) ->
+    NewState = send_body(Body, State),
     {noreply, NewState};
 
-handle_cast({resend_raw, Transport, Body}, State) ->
-    NewState = send(Transport, Body, make_ref(), State#state.rid, State),
+handle_cast({resend_raw, Body}, State) ->
+    NewState = send_body(Body, make_ref(), State#state.rid, State),
     {noreply, NewState};
 
-handle_cast({pause, Transport, Seconds},
-            #state{rid = Rid, sid = Sid} = State) ->
-    NewState = send(Transport, pause_body(Rid, Sid, Seconds), State),
+handle_cast({pause, Seconds}, #state{rid = Rid, sid = Sid} = State) ->
+    NewState = send_body(pause_body(Rid, Sid, Seconds), State),
     {noreply, NewState};
 
 handle_cast(reset_parser, #state{parser = Parser} = State) ->
     {ok, NewParser} = exml_stream:reset_parser(Parser),
     {noreply, State#state{parser = NewParser}}.
 
-
 %% Handle async HTTP request replies.
 -spec handle_info(term(), state()) -> {noreply, state()}.
 handle_info(_, #state{ terminated = true } = S) ->
     {noreply, S};
-handle_info({http_reply, Ref, Body, Transport} = HttpReply,
+handle_info({http_reply, Ref, Body, _Transport} = HttpReply,
             #state{ pending_replies = PendingReplies } = S0) ->
     {ok, #xmlel{attrs = Attrs} = XmlBody} = exml:parse(Body),
     NewS = case {queue:peek(S0#state.requests),
                  S0#state.quickfail andalso detect_type(Attrs) == streamend} of
                {_, true} ->
-                   S1 = handle_http_reply(Ref, XmlBody, Transport, S0),
+                   S1 = handle_http_reply(Ref, XmlBody, S0),
                    S1#state{ pending_replies = [] };
                {{value, {Ref, _Rid, _Pid}}, _} ->
                    {{value, {Ref, _Rid, _Pid}}, NewRequests} = queue:out(S0#state.requests),
-                   S1 = handle_http_reply(Ref, XmlBody, Transport,
-                                          S0#state{ requests = NewRequests }),
+                   S1 = handle_http_reply(Ref, XmlBody, S0#state{ requests = NewRequests }),
                    lists:foreach(fun(PendingReply) -> self() ! PendingReply end,
                                  S1#state.pending_replies),
                    S1#state{ pending_replies = [] };
@@ -439,7 +444,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Helpers
 %%%===================================================================
 
-request(#client{socket = {Client, Path}}, Body, OnReplyFun) ->
+request(Client, Path, Body, OnReplyFun) ->
     Headers = [{<<"Content-Type">>, <<"text/xml; charset=utf-8">>}],
     BodyIO = exml:to_iolist(Body),
     Reply = fusco_cp:request(Client, Path, "POST", Headers, BodyIO, 2, infinity),
@@ -451,35 +456,35 @@ close_requests(#state{requests = Reqs} = S) ->
     [exit(Pid, normal) || {_Ref, _Rid, Pid} <- queue:to_list(Reqs)],
     S#state{requests = queue:new(), pending_requests = queue:new()}.
 
-wrap_and_send(Transport, Elem, State) ->
-    wrap_and_send(Transport, Elem, make_ref(), State).
+wrap_and_send(Elem, State) ->
+    wrap_and_send(Elem, make_ref(), State).
 
-wrap_and_send(Transport, Elem, Ref, State) ->
-    send(Transport, wrap_elem(Elem, State), Ref, State).
+wrap_and_send(Elem, Ref, State) ->
+    send_body(wrap_elem(Elem, State), Ref, State).
 
-send(Transport, Body, State) ->
-    send(Transport, Body, make_ref(), State).
+send_body(Body, State) ->
+    send_body(Body, make_ref(), State).
 
-send(Transport, Body, Ref, State) ->
-    send(Transport, Body, Ref, State#state.rid + 1, State).
+send_body(Body, Ref, State) ->
+    send_body(Body, Ref, State#state.rid + 1, State).
 
-send(_Transport, _Body, _Ref, _NewRid, #state{ terminated = true } = S) ->
+send_body(_Body, _Ref, _NewRid, #state{ terminated = true } = S) ->
     %% Sending anything to a terminated session is pointless.
     %% We leave it in its current state to pick up any pending replies.
     S;
-send(Transport, Body, Ref, NewRid, #state{ on_reply = OnReplyFun } = State) ->
-    AsyncReq = prep_request(Transport, Body, OnReplyFun, Ref),
+send_body(Body, Ref, NewRid, #state{ on_reply = OnReplyFun } = State) ->
+    AsyncReq = prep_request(State#state.client, State#state.url, Body, OnReplyFun, Ref),
     start_request_or_enqueue(AsyncReq, State#state{ rid = NewRid }).
 
-prep_request(Transport, Body, OnReplyFun, Ref) ->
+prep_request(Client, Path, Body, OnReplyFun, Ref) ->
     Self = self(),
     % Call to send_raw may lead to this function, so we can't trust Rid from State,
     % so we extract it from Body here, since this is the Rid the server will see
     Rid = binary_to_integer(exml_query:attr(Body, <<"rid">>)),
     {Ref, Rid,
      fun() ->
-             {ok, Reply} = request(Transport, Body, OnReplyFun),
-             Self ! {http_reply, Ref, Reply, Transport}
+             {ok, Reply} = request(Client, Path, Body, OnReplyFun),
+             Self ! {http_reply, Ref, Reply, Client}
      end}.
 
 start_request_or_enqueue(AsyncReq, #state{ requests = Requests,
@@ -496,7 +501,7 @@ start_async_request({Ref, Rid, ReqFun}, #state{ requests = Requests } = State) -
     NewRequests = queue_insert_by_rid({Ref, Rid, proc_lib:spawn(ReqFun)}, Requests),
     State#state{ requests = NewRequests }.
 
-handle_http_reply(Ref, #xmlel{ attrs = Attrs } = XmlBody, Transport, #state{} = S1) ->
+handle_http_reply(Ref, #xmlel{ attrs = Attrs } = XmlBody, #state{} = S1) ->
     S2 = case queue:out(S1#state.pending_requests) of
              {empty, _} ->
                  S1;
@@ -507,7 +512,7 @@ handle_http_reply(Ref, #xmlel{ attrs = Attrs } = XmlBody, Transport, #state{} = 
     S4 = case {detect_type(Attrs), S3#state.keepalive, queue:len(S3#state.requests) == 0} of
               {streamend, _, _} -> close_requests(S3#state{terminated = true});
               {_, false, _}     -> S3;
-              {_, true, true}   -> send(Transport, empty_body(S3#state.rid, S3#state.sid), S3);
+              {_, true, true}   -> send_body(empty_body(S3#state.rid, S3#state.sid), S3);
               {_, true, false}  -> S3
           end,
     case lists:keytake(Ref, 1, S4#state.waiting_requesters) of
@@ -538,10 +543,10 @@ handle_data(#xmlel{} = Body, #state{} = State) ->
     end.
 
 forward_to_owner(Stanzas, #state{owner = Owner,
-                                 event_client = EventClient} = S) ->
+                                 event_client = EventClient}) ->
     lists:foreach(fun(Stanza) ->
         escalus_event:incoming_stanza(EventClient, Stanza),
-        Owner ! {stanza, transport(S), Stanza}
+        Owner ! {stanza, self(), Stanza}
     end, Stanzas),
     case lists:keyfind(xmlstreamend, 1, Stanzas) of
         false -> ok;
@@ -561,21 +566,13 @@ handle_recv(#state{replies = [Reply | Replies]} = S) ->
     end,
     {Reply, S#state{replies = Replies}}.
 
-transport(#state{url = Path, client = Client, event_client = EventClient}) ->
-    #client{module = ?MODULE,
-               ssl = false,
-               compress = false,
-               rcv_pid = self(),
-               socket = {Client, Path},
-               event_client = EventClient}.
-
 wrap_elem(#xmlstreamstart{attrs = Attrs},
           #state{rid = Rid, sid = Sid, wait = Wait}) ->
     Version = proplists:get_value(<<"version">>, Attrs, <<"1.0">>),
     Lang = proplists:get_value(<<"xml:lang">>, Attrs, <<"en">>),
     To = proplists:get_value(<<"to">>, Attrs, <<"localhost">>),
     session_creation_body(Wait, Version, Lang, Rid, To, Sid);
-wrap_elem(["</", <<"stream:stream">>, ">"], #state{sid=Sid, rid=Rid}) ->
+wrap_elem(#xmlstreamend{}, #state{sid=Sid, rid=Rid}) ->
     session_termination_body(Rid, Sid);
 wrap_elem(Element, #state{sid = Sid, rid=Rid}) ->
     (empty_body(Rid, Sid))#xmlel{children = [Element]}.

--- a/src/escalus_cleaner.erl
+++ b/src/escalus_cleaner.erl
@@ -27,7 +27,8 @@
 % Public API
 -export([start/1,
          add_client/2,
-         clean/1,
+         remove_client/2,
+         get_clients/1,
          stop/1]).
 
 -behaviour(gen_server).
@@ -46,20 +47,30 @@
         clients = [] :: [pid()]
 }).
 
+-type state() :: #state{}.
+
 %%%===================================================================
 %%% Public API
 %%%===================================================================
 
+-spec start(escalus:config()) -> escalus:config().
 start(Config) ->
     {ok, Pid} = gen_server:start_link(?MODULE, [], []),
     [{escalus_cleaner, Pid} | Config].
 
+-spec add_client(escalus:config(), escalus:client()) -> ok.
 add_client(Config, Client) ->
-    gen_server:cast(get_cleaner(Config), {add_client, Client}).
+    gen_server:call(get_cleaner(Config), {add_client, Client}).
 
-clean(Config) ->
-    gen_server:call(get_cleaner(Config), clean).
+-spec remove_client(escalus:config(), escalus:client()) -> ok.
+remove_client(Config, Client) ->
+    gen_server:call(get_cleaner(Config), {remove_client, Client}).
 
+-spec get_clients(escalus:config()) -> [escalus:client()].
+get_clients(Config) ->
+    gen_server:call(get_cleaner(Config), get_clients).
+
+-spec stop(escalus:config()) -> ok.
 stop(Config) ->
     gen_server:cast(get_cleaner(Config), stop).
 
@@ -67,27 +78,36 @@ stop(Config) ->
 %%% gen_server callbacks
 %%%===================================================================
 
+-spec init(list()) -> {ok, state()}.
 init([]) ->
     {ok, #state{}}.
 
-handle_call(clean, _From, #state{clients = Clients} = State) ->
-    lists:foreach(fun escalus_client:stop/1, Clients),
-    {reply, ok, State#state{clients = []}}.
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}
+                                                           | {noreply, state()}
+                                                           | {stop, normal, ok, state()}.
+handle_call({add_client, Client}, _From, #state{clients = Clients} = State) ->
+    {reply, ok, State#state{clients = [Client | Clients]}};
+handle_call({remove_client, Client}, _From, #state{clients = Clients} = State) ->
+    {reply, ok, State#state{clients = Clients -- [Client]}};
+handle_call(get_clients, _From, #state{clients = Clients} = State) ->
+    {reply, Clients, State}.
 
-handle_cast({add_client, Pid}, #state{clients = Clients} = State) ->
-    {noreply, State#state{clients = [Pid | Clients]}};
+-spec handle_cast(term(), state()) -> {noreply, state()} | {stop, normal, state()}.
 handle_cast(stop, State) ->
     {stop, normal, State}.
 
+-spec handle_info(term(), state()) -> {noreply, state()}.
 handle_info(_Info, State) ->
     {noreply, State}.
 
+-spec terminate(term(), state()) -> term().
 terminate(_Reason, #state{clients = []}) ->
     ok;
 terminate(_Reason, #state{clients = Clients}) ->
     error_logger:warning_msg("cleaner finishes dirty: ~p~n", [Clients]),
     ok.
 
+-spec code_change(term(), state(), term()) -> {ok, state()}.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 

--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -21,7 +21,9 @@
          start/3,
          send/2,
          send_and_wait/2,
-         stop/1,
+         stop/2,
+         wait_for_close/3,
+         kill_connection/2,
          kill/1,
          peek_stanzas/1, has_stanzas/1,
          wait_for_stanzas/2, wait_for_stanzas/3,
@@ -35,8 +37,6 @@
         ]).
 
 -export_type([client/0]).
-
--import(escalus_compat, [bin/1, unimplemented/0]).
 
 -define(WAIT_FOR_STANZA_TIMEOUT, 1000).
 
@@ -55,41 +55,59 @@ start(Config, UserSpec, Resource) ->
     EventClient = escalus_event:new_client(Config, UserSpec, Resource),
     Options = escalus_users:get_options(Config, UserSpec, Resource, EventClient),
     case escalus_connection:start(Options) of
-        {ok, Conn, Props, _} ->
-            Jid = make_jid(Props),
-            Client = Conn#client{jid = Jid, event_client = EventClient},
+        {ok, Conn, _} ->
+            Client = Conn#client{event_client = EventClient},
             escalus_cleaner:add_client(Config, Client),
             {ok, Client};
         {error, Error} ->
             {error, Error}
     end.
 
-start_for(Config, Username, Resource) ->
+-spec start_for(escalus:config(), escalus_users:user_spec(), binary()) -> {ok, _}
+                                                                        | {error, _}.
+start_for(Config, UserSpec, Resource) ->
     %% due to escalus_client:get_user_option hack,
     %% those two are equivalent now
-    start(Config, Username, Resource).
+    start(Config, UserSpec, Resource).
 
-stop(Conn) ->
-    escalus_connection:stop(Conn).
+-spec stop(escalus:config(), client()) -> ok.
+stop(Config, Client) ->
+    escalus_connection:stop(Client),
+    escalus_cleaner:remove_client(Config, Client).
 
+-spec kill_connection(escalus:config(), client()) -> ok.
+kill_connection(Config, Client) ->
+    escalus_connection:kill(Client),
+    escalus_cleaner:remove_client(Config, Client).
+
+-spec wait_for_close(escalus:config(), client(), non_neg_integer()) -> ok.
+wait_for_close(Config, Client, Timeout) ->
+    true = escalus_connection:wait_for_close(Client, Timeout),
+    escalus_cleaner:remove_client(Config, Client).
+
+-spec kill(client()) -> term().
 kill(#client{module = escalus_tcp, rcv_pid = Pid}) ->
     erlang:exit(Pid, kill).
 
+-spec peek_stanzas(client()) -> [exml:element()].
 peek_stanzas(#client{rcv_pid = Pid}) ->
     {messages, Msgs} = process_info(self(), messages),
-    lists:flatmap(fun ({stanza, #client{rcv_pid = StanzaPid}, Stanza}) when Pid == StanzaPid ->
+    lists:flatmap(fun ({stanza, StanzaPid, Stanza}) when Pid == StanzaPid ->
                           [Stanza];
                       %% FIXME: stream error
                       (_) ->
                           []
                  end, Msgs).
 
+-spec has_stanzas(client()) -> boolean().
 has_stanzas(Client) ->
     peek_stanzas(Client) /= [].
 
+-spec wait_for_stanzas(client(), non_neg_integer()) -> [exml:element()].
 wait_for_stanzas(Client, Count) ->
     wait_for_stanzas(Client, Count, ?WAIT_FOR_STANZA_TIMEOUT).
 
+-spec wait_for_stanzas(client(), non_neg_integer(), non_neg_integer()) -> [exml:element()].
 wait_for_stanzas(Client, Count, Timeout) ->
     Tref = erlang:send_after(Timeout, self(), TimeoutMsg={timeout, make_ref()}),
     Result = do_wait_for_stanzas(Client, Count, TimeoutMsg, []),
@@ -101,7 +119,7 @@ do_wait_for_stanzas(_Client, 0, _TimeoutMsg, Acc) ->
 do_wait_for_stanzas(#client{event_client=EventClient, jid=Jid, rcv_pid=Pid} = Client,
                     Count, TimeoutMsg, Acc) ->
     receive
-        {stanza, #client{rcv_pid = Pid}, Stanza} ->
+        {stanza, Pid, Stanza} ->
             escalus_event:pop_incoming_stanza(EventClient, Stanza),
             escalus_ct:log_stanza(Jid, in, Stanza),
             do_wait_for_stanzas(Client, Count - 1, TimeoutMsg, [Stanza|Acc]);
@@ -110,9 +128,11 @@ do_wait_for_stanzas(#client{event_client=EventClient, jid=Jid, rcv_pid=Pid} = Cl
             do_wait_for_stanzas(Client, 0, TimeoutMsg, Acc)
     end.
 
+-spec wait_for_stanza(client()) -> exml:element().
 wait_for_stanza(Client) ->
     wait_for_stanza(Client, ?WAIT_FOR_STANZA_TIMEOUT).
 
+-spec wait_for_stanza(client(), non_neg_integer()) -> exml:element().
 wait_for_stanza(Client, Timeout) ->
     case wait_for_stanzas(Client, 1, Timeout) of
         [Stanza] ->
@@ -121,27 +141,34 @@ wait_for_stanza(Client, Timeout) ->
             error(timeout_when_waiting_for_stanza, [Client, Timeout])
     end.
 
+-spec send(client(), exml:element()) -> ok.
 send(Client, Packet) ->
     escalus_connection:send(Client, Packet).
 
+-spec send_and_wait(client(), exml:element()) -> exml:element().
 send_and_wait(Client, Packet) ->
     ok = send(Client, Packet),
     wait_for_stanza(Client).
 
+-spec is_client(term()) -> boolean().
 is_client(#client{}) ->
     true;
 is_client(_) ->
     false.
 
+-spec full_jid(client()) -> binary() | undefined.
 full_jid(#client{jid=Jid}) ->
     Jid.
 
+-spec short_jid(client()) -> binary().
 short_jid(Client) ->
     escalus_utils:regexp_get(full_jid(Client), <<"^([^/]*)">>).
 
+-spec username(client()) -> binary().
 username(Client) ->
     escalus_utils:regexp_get(full_jid(Client), <<"^([^@]*)">>).
 
+-spec server(client()) -> binary().
 server(Client) ->
     escalus_utils:regexp_get(full_jid(Client), <<"^[^@]*[@]([^/]*)">>).
 
@@ -149,12 +176,3 @@ server(Client) ->
 resource(Client) ->
     escalus_utils:get_resource(full_jid(Client)).
 
-%%--------------------------------------------------------------------
-%% helpers
-%%--------------------------------------------------------------------
-
-make_jid(Proplist) ->
-    {username, U} = lists:keyfind(username, 1, Proplist),
-    {server, S} = lists:keyfind(server, 1, Proplist),
-    {resource, R} = lists:keyfind(resource, 1, Proplist),
-    <<U/binary, "@", S/binary, "/", R/binary>>.

--- a/src/escalus_session.erl
+++ b/src/escalus_session.erl
@@ -5,30 +5,30 @@
 %%%===================================================================
 
 -module(escalus_session).
--export([start_stream/2,
-         authenticate/2,
-         starttls/2,
-         bind/2,
-         compress/2,
+-export([start_stream/1,
+         authenticate/1,
+         starttls/1,
+         bind/1,
+         compress/1,
          use_ssl/2,
          can_use_amp/2,
          can_use_compression/2,
          can_use_stream_management/2,
-         session/2]).
+         session/1]).
 
 %% New style connection initiation
--export([start_stream/3,
-         stream_features/3,
-         maybe_use_ssl/3,
-         maybe_use_carbons/3,
-         maybe_use_compression/3,
-         maybe_stream_management/3,
-         maybe_stream_resumption/3,
-         stream_management/3,
-         stream_resumption/3,
-         authenticate/3,
-         bind/3,
-         session/3]).
+-export([start_stream/2,
+         stream_features/2,
+         maybe_use_ssl/2,
+         maybe_use_carbons/2,
+         maybe_use_compression/2,
+         maybe_stream_management/2,
+         maybe_stream_resumption/2,
+         stream_management/2,
+         stream_resumption/2,
+         authenticate/2,
+         bind/2,
+         session/2]).
 
 %% Public Types
 -export_type([feature/0,
@@ -38,14 +38,10 @@
 
 -type feature() :: {atom(), any()}.
 -type features() :: [feature()].
--define(CONNECTION_STEP, (escalus_connection:client(),
-                          escalus_users:user_spec(),
-                          features()) -> step_state()).
+-define(CONNECTION_STEP, (escalus_connection:client(), features()) -> step_state()).
 -define(CONNECTION_STEP_SIG(Module), Module?CONNECTION_STEP).
 -type step() :: fun(?CONNECTION_STEP).
--type step_state() :: {escalus_connection:client(),
-                       escalus_users:user_spec(),
-                       features()}.
+-type step_state() :: {escalus_connection:client(), features()}.
 
 %% Some shorthands
 -type client() :: escalus_connection:client().
@@ -54,87 +50,86 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("exml/include/exml_stream.hrl").
 -include("escalus_xmlns.hrl").
+-include("escalus.hrl").
 -define(DEFAULT_RESOURCE, <<"escalus-default-resource">>).
 
 %%%===================================================================
 %%% Public API
 %%%===================================================================
 
--spec start_stream(client(), user_spec()) -> {user_spec(), features()}.
-start_stream(Conn, Props) ->
-    {server, Server} = lists:keyfind(server, 1, Props),
-    NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
-    Transport = proplists:get_value(transport, Props, escalus_tcp),
-    IsLegacy = proplists:get_value(wslegacy, Props, false),
-    StreamStartReq = case {Transport, IsLegacy} of
-                         {escalus_ws, false} -> escalus_stanza:ws_open(Server);
-                         _ -> escalus_stanza:stream_start(Server, NS)
-                     end,
-    ok = escalus_connection:send(Conn, StreamStartReq),
-    StreamStartRep = escalus_connection:get_stanza(Conn, wait_for_stream),
-    assert_stream_start(StreamStartRep, Transport, IsLegacy),
-    %% TODO: deprecate 2-tuple return value
-    %% To preserve the previous interface we still return a 2-tuple,
-    %% but it's guaranteed that the features will be empty.
-    {maybe_store_stream_id(StreamStartRep, Props), []}.
+-spec start_stream(client()) -> client().
+start_stream(Client = #client{props = Props}) ->
+    StreamStartRep = escalus_connection:start_stream(Client),
+    Client#client{props = maybe_store_stream_id(StreamStartRep, Props)}.
 
--spec starttls(client(), user_spec()) -> {client(), user_spec()}.
-starttls(Conn, Props) ->
-    escalus_tcp:upgrade_to_tls(Conn, Props).
+-spec starttls(client()) -> client().
+starttls(Client) ->
+    escalus_connection:send(Client, escalus_stanza:starttls()),
+    escalus_connection:get_stanza(Client, proceed),
+    escalus_connection:upgrade_to_tls(Client),
+    start_stream(Client).
 
--spec authenticate(client(), user_spec()) -> user_spec().
-authenticate(Conn, Props) ->
+-spec authenticate(client()) -> client().
+authenticate(Client = #client{props = Props}) ->
     %% FIXME: as default, select authentication scheme based on stream features
     {M, F} = proplists:get_value(auth, Props, {escalus_auth, auth_plain}),
-    PropsAfterAuth = case M:F(Conn, Props) of
+    PropsAfterAuth = case apply(M, F, [Client, Props]) of
                          ok -> Props;
                          {ok, P} when is_list(P) -> P
                      end,
-    escalus_connection:reset_parser(Conn),
-    {Props1, []} = escalus_session:start_stream(Conn, PropsAfterAuth),
-    escalus_session:stream_features(Conn, Props1, []),
-    Props1.
+    escalus_connection:reset_parser(Client),
+    Client1 = escalus_session:start_stream(Client#client{props = PropsAfterAuth}),
+    escalus_session:stream_features(Client1, []),
+    Client1.
 
--spec bind(client(), user_spec()) -> user_spec().
-bind(Conn, Props) ->
-    Resource = proplists:get_value(resource, Props, ?DEFAULT_RESOURCE),
+-spec bind(client()) -> client().
+bind(Client = #client{props = Props0}) ->
+    Resource = proplists:get_value(resource, Props0, ?DEFAULT_RESOURCE),
     BindStanza = escalus_stanza:bind(Resource),
 
-    escalus_connection:send(Conn, BindStanza),
-    BindReply = escalus_connection:get_stanza(Conn, bind_reply),
+    escalus_connection:send(Client, BindStanza),
+    BindReply = escalus_connection:get_stanza(Client, bind_reply),
     escalus:assert(is_bind_result, BindReply),
 
-    JID = exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]),
-    PropsWithResource =
-        case is_binary(JID) of
-            true -> lists:keystore(resource, 1, Props, {resource, escalus_utils:get_resource(JID)});
-            false -> Props
-        end,
-
-    case proplists:get_value(auth_method, Props) of
-        <<"SASL-ANON">> ->
-            TMPUsername = escalus_utils:get_username(JID),
-            lists:keyreplace(username, 1, PropsWithResource, {username, TMPUsername});
-        _ ->
-            PropsWithResource
+    case exml_query:path(BindReply, [{element, <<"bind">>}, {element, <<"jid">>}, cdata]) of
+        undefined ->
+            Client;
+        JID ->
+            Props1 = lists:keystore(resource, 1, Props0,
+                                    {resource, escalus_utils:get_resource(JID)}),
+            Props2 =
+            case proplists:get_value(auth_method, Props1) of
+                <<"SASL-ANON">> ->
+                    lists:keyreplace(username, 1, Props1,
+                                     {username, escalus_utils:get_username(JID)});
+                _ ->
+                    Props1
+            end,
+            escalus_connection:maybe_set_jid(Client#client{props = Props2})
     end.
 
--spec compress(client(), user_spec()) -> {client(), user_spec()}.
-compress(Conn, Props) ->
+-spec compress(client()) -> client().
+compress(Client = #client{props = Props}) ->
     case proplists:get_value(compression, Props, false) of
         false ->
-            {Conn, Props};
+            Client;
         <<"zlib">> ->
-            escalus_tcp:use_zlib(Conn, Props)
-        %% TODO: someday maybe lzw too
+            use_zlib(Client)
     end.
 
--spec session(client(), user_spec()) -> user_spec().
-session(Conn, Props) ->
-    escalus_connection:send(Conn, escalus_stanza:session()),
-    SessionReply = escalus_connection:get_stanza(Conn, session_reply),
+use_zlib(Client) ->
+    escalus_connection:send(Client, escalus_stanza:compress(<<"zlib">>)),
+    Compressed = escalus_connection:get_stanza(Client, compressed),
+    escalus:assert(is_compressed, Compressed),
+    escalus_connection:use_zlib(Client),
+    start_stream(Client).
+
+-spec session(client()) -> client().
+session(Client) ->
+    escalus_connection:send(Client, escalus_stanza:session()),
+    SessionReply = escalus_connection:get_stanza(Client, session_reply),
     escalus:assert(is_iq_result, SessionReply),
-    Props.
+    Client.
 
 -spec use_ssl(user_spec(), features()) -> boolean().
 use_ssl(Props, Features) ->
@@ -173,120 +168,103 @@ can_use(Feature, Props, Features) ->
 %%%===================================================================
 
 -spec ?CONNECTION_STEP_SIG(start_stream).
-start_stream(Conn, Props, [] = _Features) ->
-    {Props1, []} = start_stream(Conn, Props),
-    {Conn, Props1, []}.
+start_stream(Client, [] = _Features) ->
+    Client1 = start_stream(Client),
+    {Client1, []}.
 
 -spec ?CONNECTION_STEP_SIG(stream_features).
-stream_features(Conn, Props, [] = _Features) ->
-    StreamFeatures = escalus_connection:get_stanza(Conn, wait_for_features),
+stream_features(Client = #client{props = Props}, [] = _Features) ->
+    StreamFeatures = escalus_connection:get_stanza(Client, wait_for_features),
     Transport = proplists:get_value(transport, Props, tcp),
     IsLegacy = proplists:get_value(wslegacy, Props, false),
     assert_stream_features(StreamFeatures, Transport, IsLegacy),
-    {Conn, Props, get_stream_features(StreamFeatures)}.
+    {Client, get_stream_features(StreamFeatures)}.
 
 -spec ?CONNECTION_STEP_SIG(maybe_use_ssl).
-maybe_use_ssl(Conn, Props, Features) ->
+maybe_use_ssl(Client = #client{props = Props}, Features) ->
     case use_ssl(Props, Features) of
         true ->
-            {Conn1, Props1} = starttls(Conn, Props),
-            {Conn2, Props2, Features2} = stream_features(Conn1, Props1, []),
-            {Conn2, Props2, Features2};
+            Client1 = starttls(Client),
+            {Client2, Features2} = stream_features(Client1, []),
+            {Client2, Features2};
         false ->
-            {Conn, Props, Features}
+            {Client, Features}
     end.
 
 -spec ?CONNECTION_STEP_SIG(maybe_use_carbons).
-maybe_use_carbons(Conn, Props, Features) ->
+maybe_use_carbons(Client = #client{props = Props}, Features) ->
     case can_use_carbons(Props, Features) of
         true ->
-            use_carbons(Conn, Props, Features);
+            use_carbons(Client, Features);
         false ->
-            {Conn, Props, Features}
+            {Client, Features}
     end.
 
 -spec ?CONNECTION_STEP_SIG(use_carbons).
-use_carbons(Conn, Props, Features) ->
-    escalus_connection:send(Conn, escalus_stanza:carbons_enable()),
-    Result = escalus_connection:get_stanza(Conn, carbon_iq_response),
+use_carbons(Client, Features) ->
+    escalus_connection:send(Client, escalus_stanza:carbons_enable()),
+    Result = escalus_connection:get_stanza(Client, carbon_iq_response),
     escalus:assert(is_iq, [<<"result">>], Result),
-    {Conn, Props, Features}.
+    {Client, Features}.
 
 -spec ?CONNECTION_STEP_SIG(maybe_use_compression).
-maybe_use_compression(Conn, Props, Features) ->
+maybe_use_compression(Client = #client{props = Props}, Features) ->
     case can_use_compression(Props, Features) of
         true ->
-            {Conn1, Props1} = compress(Conn, Props),
-            {Conn2, Props2, Features2} = stream_features(Conn1, Props1, []),
-            {Conn2, Props2, Features2};
+            Client1 = compress(Client),
+            stream_features(Client1, []);
         false ->
-            {Conn, Props, Features}
+            {Client, Features}
     end.
 
 -spec ?CONNECTION_STEP_SIG(maybe_stream_management).
-maybe_stream_management(Conn, Props, Features) ->
+maybe_stream_management(Client = #client{props = Props}, Features) ->
     case can_use_stream_management(Props, Features) of
         true ->
-            stream_management(Conn, Props, Features);
+            stream_management(Client, Features);
         false ->
-            {Conn, Props, Features}
+            {Client, Features}
     end.
 
 -spec ?CONNECTION_STEP_SIG(stream_management).
-stream_management(Conn, Props, Features) ->
-    escalus_connection:send(Conn, escalus_stanza:enable_sm()),
-    Enabled = escalus_connection:get_stanza(Conn, stream_management),
+stream_management(Client, Features) ->
+    escalus_connection:send(Client, escalus_stanza:enable_sm()),
+    Enabled = escalus_connection:get_stanza(Client, stream_management),
     true = escalus_pred:is_sm_enabled(Enabled),
-    {Conn, Props, Features}.
+    {Client, Features}.
 
 -spec ?CONNECTION_STEP_SIG(maybe_stream_resumption).
-maybe_stream_resumption(Conn, Props, Features) ->
+maybe_stream_resumption(Client = #client{props = Props}, Features) ->
     case can_use_stream_management(Props, Features) of
         true ->
-            stream_resumption(Conn, Props, Features);
+            stream_resumption(Client, Features);
         false ->
-            {Conn, Props, Features}
+            {Client, Features}
     end.
 
 -spec ?CONNECTION_STEP_SIG(stream_resumption).
-stream_resumption(Conn, Props, Features) ->
-    escalus_connection:send(Conn, escalus_stanza:enable_sm([resume])),
-    Enabled = escalus_connection:get_stanza(Conn, stream_resumption),
+stream_resumption(Client = #client{props = Props}, Features) ->
+    escalus_connection:send(Client, escalus_stanza:enable_sm([resume])),
+    Enabled = escalus_connection:get_stanza(Client, stream_resumption),
     true = escalus_pred:is_sm_enabled([resume], Enabled),
     SMID = exml_query:attr(Enabled, <<"id">>),
-    {Conn, [{smid, SMID} | Props], Features}.
+    {Client#client{props = [{smid, SMID} | Props]}, Features}.
 
 -spec ?CONNECTION_STEP_SIG(authenticate).
-authenticate(Conn, Props, Features) ->
-    {Conn, authenticate(Conn, Props), Features}.
+authenticate(Client, Features) ->
+    {authenticate(Client), Features}.
 
 -spec ?CONNECTION_STEP_SIG(bind).
-bind(Conn, Props, Features) ->
-    {Conn, bind(Conn, Props), Features}.
+bind(Client, Features) ->
+    {bind(Client), Features}.
 
 -spec ?CONNECTION_STEP_SIG(session).
-session(Conn, Props, Features) ->
-    {Conn, session(Conn, Props), Features}.
+session(Client, Features) ->
+    {session(Client), Features}.
 
 %%%===================================================================
 %%% Helpers
 %%%===================================================================
-
-assert_stream_start(StreamStartRep, Transport, IsLegacy) ->
-    case {StreamStartRep, Transport, IsLegacy} of
-        {#xmlel{name = <<"open">>}, escalus_ws, false} ->
-            ok;
-        {#xmlel{name = <<"open">>}, escalus_ws, true} ->
-            error("<open/> with legacy WebSocket",
-                  [StreamStartRep]);
-        {#xmlstreamstart{}, escalus_ws, false} ->
-            error("<stream:stream> with non-legacy WebSocket",
-                  [StreamStartRep]);
-        {#xmlstreamstart{}, _, _} ->
-            ok;
-        _ ->
-            error("Not a valid stream start", [StreamStartRep])
-    end.
 
 assert_stream_features(StreamFeatures, Transport, IsLegacy) ->
     case {StreamFeatures, Transport, IsLegacy} of

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -16,12 +16,15 @@
          send/2,
          is_connected/1,
          upgrade_to_tls/2,
-         use_zlib/2,
-         get_transport/1,
+         use_zlib/1,
          reset_parser/1,
+         set_filter_predicate/2,
          stop/1,
          kill/1,
-         set_filter_predicate/2]).
+         stream_start_req/1,
+         stream_end_req/1,
+         assert_stream_start/2,
+         assert_stream_end/2]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -37,29 +40,31 @@
 
 -record(state, {owner, socket, parser, legacy_ws, compress = false,
                 event_client, filter_pred}).
+-type state() :: #state{}.
 
 %%%===================================================================
 %%% API
 %%%===================================================================
 
--spec connect([proplists:property()]) -> {ok, escalus:client()}.
+-spec connect([proplists:property()]) -> pid().
 connect(Args) ->
     {ok, Pid} = gen_server:start_link(?MODULE, [Args, self()], []),
-    Transport = gen_server:call(Pid, get_transport),
-    {ok, Transport}.
+    Pid.
 
-send(#client{rcv_pid = Pid, compress = {zlib, {_, Zout}}}, Elem) ->
-    gen_server:cast(Pid, {send_compressed, Zout, Elem});
-send(#client{rcv_pid = Pid}, Elem) ->
-    gen_server:cast(Pid, {send, exml:to_iolist(Elem)}).
+-spec send(pid(), exml:element()) -> ok.
+send(Pid, Elem) ->
+    gen_server:cast(Pid, {send, Elem}).
 
-is_connected(#client{rcv_pid = Pid}) ->
+-spec is_connected(pid()) -> boolean().
+is_connected(Pid) ->
     erlang:is_process_alive(Pid).
 
-reset_parser(#client{rcv_pid = Pid}) ->
+-spec reset_parser(pid()) -> ok.
+reset_parser(Pid) ->
     gen_server:cast(Pid, reset_parser).
 
-stop(#client{rcv_pid = Pid}) ->
+-spec stop(pid()) -> ok | already_stopped.
+stop(Pid) ->
     try
         gen_server:call(Pid, stop)
     catch
@@ -69,31 +74,81 @@ stop(#client{rcv_pid = Pid}) ->
             already_stopped
     end.
 
-kill(#client{rcv_pid = Pid}) ->
+-spec kill(pid()) -> ok | already_stopped.
+kill(Pid) ->
     %% Use `kill_connection` to avoid confusion with exit reason `kill`.
-    gen_server:call(Pid, kill_connection).
+    try
+        gen_server:call(Pid, kill_connection)
+    catch
+        exit:{noproc, {gen_server, call, _}} ->
+            already_stopped;
+        exit:{normal, {gen_server, call, _}} ->
+            already_stopped
+    end.
 
--spec set_filter_predicate(escalus_connection:client(),
-    escalus_connection:filter_pred()) -> ok.
-set_filter_predicate(#client{rcv_pid = Pid}, Pred) ->
+-spec set_filter_predicate(pid(), escalus_connection:filter_pred()) -> ok.
+set_filter_predicate(Pid, Pred) ->
     gen_server:call(Pid, {set_filter_pred, Pred}).
 
-
+-spec upgrade_to_tls(_, _) -> no_return().
 upgrade_to_tls(_, _) ->
     throw(starttls_not_supported).
 
-%% TODO: this is en exact duplicate of escalus_tcp:use_zlib/2, DRY!
-use_zlib(#client{rcv_pid = Pid} = Client, Props) ->
-    escalus_connection:send(Client, escalus_stanza:compress(<<"zlib">>)),
-    Compressed = escalus_connection:get_stanza(Client, compressed),
-    escalus:assert(is_compressed, Compressed),
-    gen_server:call(Pid, use_zlib),
-    Client1 = get_transport(Client),
-    {Props2, _} = escalus_session:start_stream(Client1, Props),
-    {Client1, Props2}.
+-spec use_zlib(pid()) -> ok.
+use_zlib(Pid) ->
+    gen_server:call(Pid, use_zlib).
 
-get_transport(#client{rcv_pid = Pid}) ->
-    gen_server:call(Pid, get_transport).
+-spec stream_start_req(escalus_users:user_spec()) -> exml_stream:element().
+stream_start_req(Props) ->
+    {server, Server} = lists:keyfind(server, 1, Props),
+    case proplists:get_value(wslegacy, Props, false) of
+        true ->
+            NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
+            escalus_stanza:stream_start(Server, NS);
+        false ->
+            escalus_stanza:ws_open(Server)
+    end.
+
+-spec stream_end_req(_) -> exml_stream:element().
+stream_end_req(Props) ->
+    case proplists:get_value(wslegacy, Props, false) of
+        true -> escalus_stanza:stream_end();
+        false -> escalus_stanza:ws_close()
+    end.
+
+-spec assert_stream_start(exml_stream:element(), _) -> exml_stream:element().
+assert_stream_start(StreamStartRep, Props) ->
+    case {StreamStartRep, proplists:get_value(wslegacy, Props, false)} of
+        {#xmlel{name = <<"open">>}, false} ->
+            StreamStartRep;
+        {#xmlel{name = <<"open">>}, true} ->
+            error("<open/> with legacy WebSocket",
+                  [StreamStartRep]);
+        {#xmlstreamstart{}, false} ->
+            error("<stream:stream> with non-legacy WebSocket",
+                  [StreamStartRep]);
+        {#xmlstreamstart{}, _} ->
+            StreamStartRep;
+        _ ->
+            error("Not a valid stream start", [StreamStartRep])
+    end.
+
+-spec assert_stream_end(exml_stream:element(), _) -> exml_stream:element().
+assert_stream_end(StreamEndRep, Props) ->
+    case {StreamEndRep, proplists:get_value(wslegacy, Props, false)} of
+        {#xmlel{name = <<"close">>}, false} ->
+            StreamEndRep;
+        {#xmlel{name = <<"close">>}, true} ->
+            error("<close/> with legacy WebSocket",
+                  [StreamEndRep]);
+        {#xmlstreamend{}, false} ->
+            error("<stream:stream> with non-legacy WebSocket",
+                  [StreamEndRep]);
+        {#xmlstreamend{}, _} ->
+            StreamEndRep;
+        _ ->
+            error("Not a valid stream end", [StreamEndRep])
+    end.
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -101,6 +156,7 @@ get_transport(#client{rcv_pid = Pid}) ->
 
 %% TODO: refactor all opt defaults taken from Args into a default_opts function,
 %%       so that we know what options the module actually expects
+-spec init(list()) -> {ok, state()}.
 init([Args, Owner]) ->
     Host = get_host(Args, "localhost"),
     Port = get_port(Args, 5280),
@@ -122,60 +178,43 @@ init([Args, Owner]) ->
                  end,
     {ok, Parser} = exml_stream:new_parser(ParserOpts),
     {ok, #state{owner = Owner,
-                socket = Socket,
+                 socket = Socket,
                 parser = Parser,
                 legacy_ws = LegacyWS,
                 event_client = EventClient}}.
 
-handle_call(get_transport, _From, State) ->
-    {reply, transport(State), State};
-handle_call(use_zlib, _, #state{parser = Parser, socket = Socket} = State) ->
+-spec handle_call(term(), {pid(), term()}, state()) ->
+    {reply, term(), state()} | {stop, normal, ok, state()}.
+handle_call(use_zlib, _, #state{parser = Parser} = State) ->
     Zin = zlib:open(),
     Zout = zlib:open(),
     ok = zlib:inflateInit(Zin),
     ok = zlib:deflateInit(Zout),
     {ok, NewParser} = exml_stream:reset_parser(Parser),
-    {reply, Socket, State#state{parser = NewParser,
-                                compress = {zlib, {Zin,Zout}}}};
+    {reply, ok, State#state{parser = NewParser,
+                            compress = {zlib, {Zin, Zout}}}};
 handle_call({set_filter_pred, Pred}, _From, State) ->
     {reply, ok, State#state{filter_pred = Pred}};
 handle_call(kill_connection, _, S) ->
     {stop, normal, ok, S};
-handle_call(stop, _From, #state{socket = Socket,
-                                compress = Compress} = State) ->
-    StreamEnd = if
-                    State#state.legacy_ws -> escalus_stanza:stream_end();
-                    true -> escalus_stanza:ws_close()
-                end,
-    case Compress of
-        {zlib, {Zin, Zout}} ->
-            try
-                ok = zlib:inflateEnd(Zin)
-            catch
-                error:data_error -> ok
-            end,
-            ok = zlib:close(Zin),
-            wsecli:send(Socket, zlib:deflate(Zout,
-                                             exml:to_iolist(StreamEnd),
-                                             finish)),
-            ok = zlib:deflateEnd(Zout),
-            ok = zlib:close(Zout);
-        false ->
-            wsecli:send(Socket, exml:to_iolist(StreamEnd))
-    end,
+handle_call(stop, _From, State) ->
+    close_compression_streams(State#state.compress),
     wait_until_closed(),
     {stop, normal, ok, State}.
 
-handle_cast({send_compressed, Zout, Elem}, State) ->
-    wsecli:send(State#state.socket, zlib:deflate(Zout, exml:to_iolist(Elem), sync)),
-    {noreply, State};
-handle_cast({send, Data}, State) ->
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast({send, Elem}, State) ->
+    Data = case State#state.compress of
+               {zlib, {_, Zout}} -> zlib:deflate(Zout, exml:to_iolist(Elem), sync);
+               false -> exml:to_iolist(Elem)
+           end,
     wsecli:send(State#state.socket, Data),
     {noreply, State};
 handle_cast(reset_parser, #state{parser = Parser} = State) ->
     {ok, NewParser} = exml_stream:reset_parser(Parser),
     {noreply, State#state{parser = NewParser}}.
 
+-spec handle_info(term(), state()) -> {noreply, state()} | {stop, term(), state()}.
 handle_info(tcp_closed, State) ->
     {stop, normal, State};
 handle_info({error, Reason}, State) ->
@@ -187,10 +226,12 @@ handle_info({binary, Data}, State) ->
 handle_info(_, State) ->
     {noreply, State}.
 
-terminate(_Reason, #state{socket = Socket} = State) ->
-    common_terminate(_Reason, State),
+-spec terminate(term(), state()) -> term().
+terminate(Reason, #state{socket = Socket} = State) ->
+    common_terminate(Reason, State),
     wsecli:stop(Socket).
 
+-spec code_change(term(), state(), term()) -> {ok, state()}.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
@@ -223,24 +264,14 @@ is_stream_end(#xmlstreamend{}) -> true;
 is_stream_end(_) -> false.
 
 forward_to_owner(Stanzas, #state{owner = Owner,
-                                 event_client = EventClient} = NewState) ->
+                                 event_client = EventClient}) ->
     lists:foreach(fun(Stanza) ->
                           escalus_event:incoming_stanza(EventClient, Stanza),
-                          Owner ! {stanza, transport(NewState), Stanza}
+                          Owner ! {stanza, self(), Stanza}
                   end, Stanzas).
 
 common_terminate(_Reason, #state{parser = Parser}) ->
     exml_stream:free_parser(Parser).
-
-transport(#state{socket = Socket,
-                 compress = Compress,
-                 event_client = EventClient}) ->
-    #client{module = ?MODULE,
-               socket = Socket,
-               ssl = false,
-               compress = Compress,
-               rcv_pid = self(),
-               event_client = EventClient}.
 
 wait_until_closed() ->
     receive
@@ -284,3 +315,19 @@ get_option(Key, Opts, Default) ->
         false -> Default;
         {Key, Value} -> Value
     end.
+
+close_compression_streams(false) ->
+    ok;
+close_compression_streams({zlib, {Zin, Zout}}) ->
+    try
+        zlib:deflate(Zout, <<>>, finish),
+        ok = zlib:inflateEnd(Zin),
+        ok = zlib:deflateEnd(Zout)
+    catch
+        error:data_error -> ok
+    after
+        ok = zlib:close(Zin),
+        ok = zlib:close(Zout)
+    end.
+
+


### PR DESCRIPTION
- Close the stream and connection in a clean way.
- Add user properties to the 'client' record and remove low-level transport settings from it.
- Do not use the 'client' record inside the transport modules.