### PR TITLE
Really return the short JID instead of intact binary

### DIFF
--- a/src/escalus_utils.erl
+++ b/src/escalus_utils.erl
@@ -149,9 +149,9 @@ get_short_jid(#client{}=Recipient) ->
 get_short_jid(Username) when is_atom(Username) ->
     escalus_users:get_jid([], Username);
 get_short_jid(Jid) when is_list(Jid) ->
-    list_to_binary(Jid);
+    get_short_jid(list_to_binary(Jid));
 get_short_jid(Jid) when is_binary(Jid) ->
-    Jid.
+    regexp_get(Jid, <<"^([^@]*[@][^/]*)">>).
 
 -spec jid_to_lower(binary()) -> binary().
 jid_to_lower(Jid) ->


### PR DESCRIPTION
Previously `escalus_utils:get_short_jid/1` returned the binary as is.