### PR TITLE
send the end stream stanza while stopping only if connected

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -225,7 +225,12 @@ is_connected(#client{module = Mod, rcv_pid = Pid}) ->
 
 -spec stop(client()) -> ok | already_stopped.
 stop(#client{module = Mod, rcv_pid = Pid} = Client) ->
-    end_stream(Client),
+    case is_connected(Client) of
+        true ->
+            end_stream(Client);
+        _ ->
+            ok
+    end,
     Mod:stop(Pid).
 
 %% @doc Brutally kill the connection without terminating the XMPP stream.


### PR DESCRIPTION
The end stream stanza should be sent only if the stopping connection is online.
Sometimes the `escalus_connection:stop/1` can be called twice (in a story and  in escalus_story after the story).