### PR TITLE
Add an option to include maybe_stream_resumption step

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -294,7 +294,7 @@ maybe_forward_to_owner(_, State, Stanzas, Fun) ->
 get_connection_steps(UserSpec) ->
     case lists:keyfind(connection_steps, 1, UserSpec) of
         false -> default_connection_steps();
-        default_resume -> default_connection_steps(resume);
+        {_, default_resume} -> default_connection_steps(resume);
         {_, Steps} -> Steps
     end.
 

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -294,6 +294,7 @@ maybe_forward_to_owner(_, State, Stanzas, Fun) ->
 get_connection_steps(UserSpec) ->
     case lists:keyfind(connection_steps, 1, UserSpec) of
         false -> default_connection_steps();
+        default_resume -> default_connection_steps(resume);
         {_, Steps} -> Steps
     end.
 
@@ -307,6 +308,11 @@ default_connection_steps() ->
      session,
      maybe_stream_management,
      maybe_use_carbons].
+
+default_connection_steps(resume) ->
+    lists:map(fun(maybe_stream_management) -> maybe_stream_resumption;
+                 (A) -> A end,
+              default_connection_steps()).
 
 -spec start_stream(client()) -> exml_stream:element().
 start_stream(#client{module = Mod, props = Props} = Client) ->


### PR DESCRIPTION
This PR let's user tell connection module that it wants to enable stream management with `resume` option. It is now not available without specifying all the steps in `escalus_connection:start/2.` 

Now it would be enough to add `{connection_steps, default_resume}` to user spec in `escalus_connection:start/2`. This PR **does not** change the API, just extends it (with this option).

I add this as I needed it in this [PR](https://github.com/esl/MongooseIM/pull/1601)

If I miss the way I should specify that I want to use maybe_stream_resumption, let me know, please :)