### PR TITLE
Fix Rebar 3 deps format warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,14 +6,14 @@
 {require_otp_vsn, "(^1[89])|^20"}.
 
 {deps, [
-        {exml, ".*", {git, "https://github.com/esl/exml.git", "d365533"}},
-        {base16, ".*", {git, "https://github.com/goj/base16.git", "ec420aa"}},
-        {fusco, ".*", {git, "https://github.com/esl/fusco.git", "0a428471"}},
-        {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
-        {mustache, ".*", {git, "https://github.com/mojombo/mustache.erl.git", "d0246fe"}},
-        {uuid, "", {git, "https://github.com/okeuday/uuid.git", "v1.7.1"}},
-        {cowlib, ".*", {git, "https://github.com/ninenines/cowlib.git", "e4da207"}},
-        {gun, ".*", {git, "https://github.com/ninenines/gun.git", "02fa5f3"}}
+        {exml, {git, "https://github.com/esl/exml.git", {ref, "d365533"}}},
+        {base16, {git, "https://github.com/goj/base16.git", {ref, "ec420aa"}}},
+        {fusco, {git, "https://github.com/esl/fusco.git", {ref, "0a428471"}}},
+        {meck, {git, "https://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
+        {mustache, {git, "https://github.com/mojombo/mustache.erl.git", {ref, "d0246fe"}}},
+        {uuid, {git, "https://github.com/okeuday/uuid.git", {tag, "v1.7.1"}}},
+        {cowlib, {git, "https://github.com/ninenines/cowlib.git", {ref, "e4da207"}}},
+        {gun, {git, "https://github.com/ninenines/gun.git", {ref, "02fa5f3"}}}
 ]}.
 {relx, [{release, {escalus, "0.0.1"},
          [escalus]},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,17 @@
+%% Convert deps to Rebar 2 format if necessary
+case erlang:function_exported(rebar3, main, 1) of
+    true -> CONFIG;
+    false ->
+        R3Deps = proplists:get_value(deps, CONFIG),
+        R2Deps = [ {Name, "", {git, SrcURL, SrcRef}}
+                   || {Name, {git, SrcURL, {_, SrcRef}}} <- R3Deps ],
+        %% Rebar 3 accepts more dep formats than the match spec above.
+        %% Pattern match failures in comprehensions filter out elements,
+        %% so assert we didn't miss any deps.
+        if 
+            length(R2Deps) == length(R3Deps) -> ok;
+            length(R2Deps) /= length(R3Deps) ->
+                error("rebar.config.script: skipped some deps")
+        end,
+        lists:keystore(deps, 1, CONFIG, {deps, R2Deps})
+end.


### PR DESCRIPTION
Provide a rebar.config.script which converts (some) Rebar 3 dependency
specifications to a format accepted by Rebar 2.