### PR TITLE
Fail fast if a config option is undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ dialyzer: erlang_plt deps_plt escalus_plt
 	--get_warnings ebin;
 
 mongooseim-start:
-	docker run -d -t -h mongooseim-escalus-test-1 --name mongooseim-escalus-test-1 -p 5222:5222 \
+	docker run --rm -d -t -h mongooseim-escalus-test-1 --name mongooseim-escalus-test-1 -p 5222:5222 \
 		-v `pwd`/mongooseim-escalus-test-1:/member mongooseim/mongooseim:2.1.0beta2
 
-
+mongooseim-stop:
+	docker stop mongooseim-escalus-test-1

--- a/src/escalus_config.erl
+++ b/src/escalus_config.erl
@@ -42,7 +42,12 @@
 
 -spec get_config(key(), config()) -> any().
 get_config(Option, Config) ->
-    get_config(Option, Config, undefined).
+    case get_config(Option, Config, '!@#$%-fail-miserably-@#$%') of
+        '!@#$%-fail-miserably-@#$%' ->
+            error({not_found, Option}, [Option, Config]);
+        Value ->
+            Value
+    end.
 
 -spec get_config(key(), config(), any()) -> any().
 get_config(Option, Config, Default) ->

--- a/src/escalus_overridables.erl
+++ b/src/escalus_overridables.erl
@@ -41,7 +41,7 @@ override(Config, OverrideName, NewValue) ->
 %%==============================================================================
 
 get_mf(Config, OverrideName, Default) ->
-    case escalus_config:get_config(escalus_overrides, Config) of
+    case escalus_config:get_config(escalus_overrides, Config, undefined) of
         undefined ->
             Default;
         Hooks ->


### PR DESCRIPTION
This improves the reported site of error from some generic code in the standard library:

```erlang
%%% mam_SUITE ==> simple_archive_request (group main): FAILED
%%% mam_SUITE ==> {function_clause,
    [{lists,'-filter/2-lc$^0/1-0-',
         [undefined],
         [{file,"lists.erl"},{line,1286}]},
     {escalus_fresh,fresh_specs,3,
         [{file,
              "/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
          {line,81}]},
     {escalus_fresh,create_users,2,
         [{file,
              "/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
          {line,41}]},
     {escalus_fresh,story,3,
         [{file,
              "/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
          {line,15}]},
     {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1529}]},
     {test_server,run_test_case_eval1,6,
         [{file,"test_server.erl"},{line,1045}]},
     {test_server,run_test_case_eval,9,
         [{file,"test_server.erl"},{line,977}]}]}
```

To the the actual cause of our problem - an entry missing from the config:

```erlang
%%% mam_SUITE ==> simple_archive_request (group main): FAILED
%%% mam_SUITE ==> {{not_found,escalus_users},
 [{escalus_config,get_config,
                  [escalus_users,
                   [{escalus_event_mgr,<0.1065.0>},
                    {tc_name,simple_archive_request},
                    {escalus_cleaner,<0.1064.0>},
                    {watchdog,<0.1063.0>},
                    {archive_wait,2000},
                    {props,[{data_form,true},
                            {final_message,true},
                            {result_format,mess_fin},
                            {mam_ns,<<"urn:xmpp:mam:0">>}]},
                    {tc_logfile,"/Users/erszcz/work/veon/history/_build/test/logs/ct_run.nonode@nohost.2017-12-22_20.32.11/test.integration.mam_SUITE.logs/run.2017-12-22_20.32.13/mam_suite.simple_archive_request.6.html"},
                    {tc_group_properties,[{name,main},parallel]},
                    {tc_group_path,[]},
                    {data_dir,"/Users/erszcz/work/veon/history/_build/test/lib/history/test/integration/mam_SUITE_data/"},
                    {priv_dir,"/Users/erszcz/work/veon/history/_build/test/logs/ct_run.nonode@nohost.2017-12-22_20.32.11/test.integration.mam_SUITE.logs/run.2017-12-22_20.32.13/log_private/"}]],
                  [{file,"/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_config.erl"},
                   {line,48}]},
  {escalus_fresh,fresh_specs,3,
                 [{file,"/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
                  {line,79}]},
  {escalus_fresh,create_users,2,
                 [{file,"/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
                  {line,41}]},
  {escalus_fresh,story,3,
                 [{file,"/Users/erszcz/work/veon/history/_build/test/lib/escalus/src/escalus_fresh.erl"},
                  {line,15}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1529}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1045}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,977}]}]}
```