### PR TITLE
Fix story_with_config for unary StoryFuns

### DIFF
--- a/src/escalus_fresh.erl
+++ b/src/escalus_fresh.erl
@@ -1,6 +1,11 @@
 -module(escalus_fresh).
--export([story/3, story_with_config/3, create_users/2]).
--export([start/1, stop/1, clean/0]).
+-export([story/3,
+         story_with_client_list/3,
+         story_with_config/3,
+         create_users/2]).
+-export([start/1,
+         stop/1,
+         clean/0]).
 
 -type userspec() :: {atom(), integer()}.
 -type config() :: escalus:config().
@@ -13,6 +18,10 @@
 -spec story(config(), [userspec()], fun()) -> any().
 story(Config, UserSpecs, StoryFun) ->
     escalus:story(create_users(Config, UserSpecs), UserSpecs, StoryFun).
+
+-spec story_with_client_list(config(), [userspec()], fun()) -> any().
+story_with_client_list(Config, UserSpecs, StoryFun) ->
+    escalus_story:story_with_client_list(create_users(Config, UserSpecs), UserSpecs, StoryFun).
 
 %% @doc
 %% Run story with fresh users AND fresh config passed as first argument

--- a/src/escalus_fresh.erl
+++ b/src/escalus_fresh.erl
@@ -41,8 +41,8 @@ story_with_client_list(Config, UserSpecs, StoryFun) ->
 -spec story_with_config(config(), [userspec()], fun()) -> any().
 story_with_config(Config, UserSpecs, StoryFun) ->
     FreshConfig = create_users(Config, UserSpecs),
-    escalus:story(FreshConfig, UserSpecs,
-                  fun(Args) -> apply(StoryFun, [FreshConfig|Args]) end).
+    escalus_story:story_with_client_list(FreshConfig, UserSpecs,
+                                         fun(Args) -> apply(StoryFun, [FreshConfig | Args]) end).
 
 %% @doc
 %% Create fresh users for lower-level testing (NOT escalus:stories)

--- a/src/escalus_fresh.erl
+++ b/src/escalus_fresh.erl
@@ -19,6 +19,9 @@
 story(Config, UserSpecs, StoryFun) ->
     escalus:story(create_users(Config, UserSpecs), UserSpecs, StoryFun).
 
+%% @doc
+%% See escalus_story:story/3 for the difference between
+%% story/3 and story_with_client_list/3.
 -spec story_with_client_list(config(), [userspec()], fun()) -> any().
 story_with_client_list(Config, UserSpecs, StoryFun) ->
     escalus_story:story_with_client_list(create_users(Config, UserSpecs), UserSpecs, StoryFun).

--- a/src/escalus_story.erl
+++ b/src/escalus_story.erl
@@ -31,9 +31,34 @@
 %% Public API
 %%--------------------------------------------------------------------
 
+%% TODO: this doc sucks - what is "the standard format"?
+%% @doc Run an test story using the standard format:
+%%
+%%   story(Config, [{alice, 2}, {bob, 1}], fun (Alice1, Alice2, Bob) ->
+%%             ...
+%%         end).
+%%
+%% @end
 story(ConfigIn, ResourceCounts, Story) ->
     story(ConfigIn, ResourceCounts, Story, []).
 
+%% @doc Run a story, but pass all the connected clients as a list.
+%% This is needed when the number of resources is variable (pseudo-Erlang!):
+%%
+%%   story(Config, [{alice, 2}, {bob, N}], fun (Alice1, Alice2, Bob1, Bob2, ..., BobN) ->
+%%             ...
+%%         end).
+%%
+%% The closest we can get is:
+%%
+%%   story(Config, [{alice, 2}, {bob, N}], fun (Clients) ->
+%%             [Alice1, Alice2, Bob1 | BobsUpToN] = Clients,
+%%             ...
+%%         end).
+%%
+%% See carboncopy_SUITE test properties for an example:
+%% https://github.com/esl/MongooseIM/blob/f0ed90a93e17f7f3d5baf4d51bbb3f8b19826dd8/test.disabled/ejabberd_tests/tests/carboncopy_SUITE.erl#L183-L185
+%% @end
 story_with_client_list(ConfigIn, ResourceCounts, Story) ->
     story(ConfigIn, ResourceCounts, Story, [clients_as_list]).
 


### PR DESCRIPTION
This was tricky as hell to troubleshoot and then almost as tricky to fix.

In general, a `StoryFun` has more than one user involved in the story:

```erlang
    F = fun(Config, Alice, Bob) ->
        %% Alice and Bob chat
    end,
    escalus_fresh:story_with_config(Config0, [{alice, 1}, {bob, 1}], F).
```

Sometimes, though, we only need one:

```erlang
    F = fun(Config, Alice) ->
        %% Alice talks to herself
    end,
    escalus_fresh:story_with_config(Config0, [{alice, 1}], F).
```

Let's have a look at `escalus_fresh:story_with_config/3` definition:

```erlang
story_with_config(Config, UserSpecs, StoryFun) ->
    FreshConfig = create_users(Config, UserSpecs),
    escalus:story(FreshConfig, UserSpecs,
                  fun(Args) -> apply(StoryFun, [FreshConfig|Args]) end).
```

In the latter case, that is of the unary `StoryFun`, `story_with_config` failed with an obscure error:

```
=== Ended at 2018-01-02 13:33:54
=== Location: [{escalus_fresh,'-story_with_config/3-fun-0-',38},
              {escalus_story,story,40},
              {escalus_fresh,story_with_config,34},
              {test_server,ts_tc,1529},
              {test_server,run_test_case_eval1,1045},
              {test_server,run_test_case_eval,977}]
=== Reason: undefined function escalus_fresh:'-story_with_config/3-fun-0-'/3
  in function  escalus_story:story/3 (/Users/erszcz/work/some_project/some_app/_build/test/lib/escalus/src/escalus_story.erl, line 40)
  in call from escalus_fresh:story_with_config/3 (/Users/erszcz/work/some_project/some_app/_build/test/lib/escalus/src/escalus_fresh.erl, line 34)
  in call from test_server:ts_tc/3 (test_server.erl, line 1529)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1045)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 977)
```

...even though the the inline fun in `story_with_config/3` definition as well as the `StoryFun` exported from the test suite were defined (checked against disassembled BEAM code with `beam_disasm` just before the error occurred).

Let's now have a look at `escalus_story:apply_w_arity_check`:

```erlang
apply_w_arity_check(Fun, Args) when is_function(Fun, 1) ->
    case length(Args) of
        1 -> apply(Fun, Args);  %% Fun expects one logged-in user
        _ -> apply(Fun, [Args]) %% Fun expects list of users
    end;
apply_w_arity_check(Fun, Args) when is_function(Fun) ->
    apply(Fun, Args).
```

It turned out that the emergent behaviour of `[FreshConfig | Args]` in `story_with_config/3` along with `escalus_story:apply_w_arity_check/1` case _Fun expects list of users_ made `story_with_config/3` accidentally work for numbers of clients greater than 1, but otherwise produced an improper list. Passing an improper list to `erlang:apply/2` causes an unexpected error to be thrown, namely an `undef` on the caller (sic!) of `erlang:apply/2`!

To distill the error, consider the following modules:

```erlang
-module(apply_proper).
-compile([export_all]).

test() ->
    F = fun (A, B) -> io:format("~p ~p\n", [A, B]) end,
    erlang:apply(F, [a,b]).
```

```erlang
-module(apply_improper).
-compile([export_all]).

test() ->
    F = fun (A, B) -> io:format("~p ~p\n", [A, B]) end,
    erlang:apply(F, [a|b]).
```

And the following test in the shell:

```
14> apply_improper:test().
** exception error: undefined function apply_improper:test/0
15> apply_proper:test().
a b
ok
```

Unfortunately, support for stories accepting lists of users had to remain in place, as at least [MongooseIM's `carboncopy_SUITE` uses them for property based testing with a variable number of connecting clients between property runs](https://github.com/esl/MongooseIM/blob/f0ed90a93e17f7f3d5baf4d51bbb3f8b19826dd8/test.disabled/ejabberd_tests/tests/carboncopy_SUITE.erl#L183-L185).

Ultimately, instead of trying to be smart behind the library API I introduced a new API function to let the caller decide how the `StoryFun` ought to be called - i.e. whether clients should be passed in as a list or directly as arguments - `carboncopy_SUITE` can use that. This also allowed to use that same function as the correct implementation of `story_with_config` which was needed from the get go.