### PR TITLE
handle all the ssl:connect/2 errors

### DIFF
--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -236,7 +236,7 @@ handle_call({upgrade_to_tls, SSLOpts}, _From, #state{socket = Socket} = State) -
             {ok, Parser} = exml_stream:new_parser(),
             {reply, Socket2,
              State#state{socket = Socket2, parser = Parser, ssl=true}};
-        {error, closed} = E ->
+        {error, _} = E ->
             {reply, E, State}
     end;
 handle_call(use_zlib, _, #state{parser = Parser} = State) ->


### PR DESCRIPTION
required for ```just_tls``` backend testing, as it closes client's connection with the alert (which is more correct according to TLS standard).

so for SSL3 connection attempt ```ssl:connect/2``` returns ```{error, {tls_alert, "protocol version"}``` 