### PR TITLE
Increase wait for stanza timeout to 5s

### DIFF
--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -38,7 +38,7 @@
 
 -export_type([client/0]).
 
--define(WAIT_FOR_STANZA_TIMEOUT, 1000).
+-define(WAIT_FOR_STANZA_TIMEOUT, 5000).
 
 -include("escalus.hrl").
 -include_lib("exml/include/exml.hrl").


### PR DESCRIPTION
I know that 1s is already long.
This change is mainly for travis builds where 1s is too short when
the infrastructure is overloaded