### PR TITLE
Add send_iq_and_wait_for_result/2,3 helpers

### DIFF
--- a/src/escalus.erl
+++ b/src/escalus.erl
@@ -41,6 +41,8 @@
          wait_for_stanza/2,
          wait_for_stanzas/2,
          wait_for_stanzas/3,
+         send_iq_and_wait_for_result/2,
+         send_iq_and_wait_for_result/3,
          peek_stanzas/1]).
 
 -export_type([client/0,
@@ -164,6 +166,12 @@ wait_for_stanzas(Client, Count, Timeout) ->
 
 peek_stanzas(Client) ->
     escalus_client:peek_stanzas(Client).
+
+send_iq_and_wait_for_result(Client, Iq) ->
+    escalus_client:send_iq_and_wait_for_result(Client, Iq).
+
+send_iq_and_wait_for_result(Client, Iq, Timeout) ->
+    escalus_client:send_iq_and_wait_for_result(Client, Iq, Timeout).
 
 %% Other functions
 


### PR DESCRIPTION
These functions send an IQ stanza and wait for response. They assert that the response is the IQ of type "result", and that its ID matches the ID of the sent request. If the 