### PR TITLE
allow to pass metadata from transport layer with the stanza erlang msg

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -546,7 +546,7 @@ forward_to_owner(Stanzas, #state{owner = Owner,
                                  event_client = EventClient}) ->
     lists:foreach(fun(Stanza) ->
         escalus_event:incoming_stanza(EventClient, Stanza),
-        Owner ! {stanza, self(), Stanza}
+        Owner ! escalus_connection:stanza_msg(Stanza, #{})
     end, Stanzas),
     case lists:keyfind(xmlstreamend, 1, Stanzas) of
         false -> ok;

--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -119,7 +119,7 @@ do_wait_for_stanzas(#client{event_client=EventClient, jid=Jid, rcv_pid=Pid} = Cl
     case escalus_connection:get_stanza_safe(Client, Timeout) of
         {error,  timeout} ->
             do_wait_for_stanzas(Client, 0, Timeout, Acc);
-        Stanza ->
+        {Stanza, _} ->
             escalus_event:pop_incoming_stanza(EventClient, Stanza),
             escalus_ct:log_stanza(Jid, in, Stanza),
             do_wait_for_stanzas(Client, Count - 1, Timeout, [Stanza|Acc])

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -75,6 +75,10 @@
 
 -type stanza_msg() :: {stanza, pid(), exml:element(), map()}.
 
+-type metadata() :: map().
+%%-type metadata() :: #{recv_timestamp := integer()}.
+%%    Above line works only on Erlang 19 or newer, that's why it's commented
+%%    as long as we support Erlang 18
 
 %%%===================================================================
 %%% Public API
@@ -191,7 +195,8 @@ get_stanza(Client, Name, Timeout) ->
             Stanza
     end.
 
--spec get_stanza_with_metadata(client(), any(), timeout()) -> {exml_stream:element(), map()}.
+-spec get_stanza_with_metadata(client(), any(), timeout()) ->
+    {exml_stream:element(), metadata()}.
 get_stanza_with_metadata(Client, Name, Timeout) ->
     case get_stanza_safe(Client, Timeout) of
         {error, timeout} ->

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -349,6 +349,7 @@ handle_data(Socket, Data, #state{parser = Parser,
                                  socket = Socket,
                                  compress = Compress,
                                  on_reply = OnReplyFun} = State) ->
+    Timestamp = os:system_time(micro_seconds),
     OnReplyFun({erlang:byte_size(Data)}),
     {ok, NewParser, Stanzas} =
         case Compress of
@@ -363,7 +364,7 @@ handle_data(Socket, Data, #state{parser = Parser,
         true ->
             escalus_connection:maybe_forward_to_owner(NewState#state.filter_pred,
                                                       NewState, Stanzas,
-                                                      fun forward_to_owner/2);
+                                                      fun forward_to_owner/3, Timestamp);
         false ->
             store_reply(Stanzas, NewState)
     end.
@@ -371,14 +372,14 @@ handle_data(Socket, Data, #state{parser = Parser,
 
 forward_to_owner(Stanzas0, #state{owner = Owner,
                                   sm_state = SM0,
-                                  event_client = EventClient} = State) ->
+                                  event_client = EventClient} = State, Timestamp) ->
     {SM1, AckRequests, StanzasNoRs} = separate_ack_requests(SM0, Stanzas0),
     reply_to_ack_requests(SM1, AckRequests, State),
     NewState = State#state{sm_state=SM1},
 
     lists:foreach(fun(Stanza) ->
         escalus_event:incoming_stanza(EventClient, Stanza),
-        Owner ! escalus_connection:stanza_msg(Stanza, #{})
+        Owner ! escalus_connection:stanza_msg(Stanza, #{recv_timestamp => Timestamp})
     end, StanzasNoRs),
 
     case lists:keyfind(xmlstreamend, 1, StanzasNoRs) of

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -378,7 +378,7 @@ forward_to_owner(Stanzas0, #state{owner = Owner,
 
     lists:foreach(fun(Stanza) ->
         escalus_event:incoming_stanza(EventClient, Stanza),
-        Owner ! {stanza, self(), Stanza}
+        Owner ! escalus_connection:stanza_msg(Stanza, #{})
     end, StanzasNoRs),
 
     case lists:keyfind(xmlstreamend, 1, StanzasNoRs) of

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -389,7 +389,7 @@ wait_for_result(Client) ->
     case escalus_connection:get_stanza_safe(Client, 5000) of
         {error, timeout} ->
             {error, timeout, exml:escape_cdata(<<"timeout">>)};
-        Stanza ->
+        {Stanza, _} ->
             case response_type(Stanza) of
                 result ->
                     {ok, result, Stanza};

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -385,9 +385,11 @@ get_defined_option(Config, Name, Short, Long) ->
                                          | {ok, conflict, exml:element()}
                                          | {error, Error, exml:cdata()}
       when Error :: 'failed_to_register' | 'bad_response' | 'timeout'.
-wait_for_result(#client{rcv_pid = Pid}) ->
-    receive
-        {stanza, Pid, Stanza} ->
+wait_for_result(Client) ->
+    case escalus_connection:get_stanza_safe(Client, 5000) of
+        {error, timeout} ->
+            {error, timeout, exml:escape_cdata(<<"timeout">>)};
+        Stanza ->
             case response_type(Stanza) of
                 result ->
                     {ok, result, Stanza};
@@ -398,8 +400,6 @@ wait_for_result(#client{rcv_pid = Pid}) ->
                 _ ->
                     {error, bad_response, Stanza}
             end
-    after 3000 ->
-            {error, timeout, exml:escape_cdata(<<"timeout">>)}
     end.
 
 response_type(#xmlel{name = <<"iq">>} = IQ) ->

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -281,7 +281,7 @@ forward_to_owner(Stanzas, #state{owner = Owner,
                                  event_client = EventClient}) ->
     lists:foreach(fun(Stanza) ->
                           escalus_event:incoming_stanza(EventClient, Stanza),
-                          Owner ! {stanza, self(), Stanza}
+                          Owner ! escalus_connection:stanza_msg(Stanza, #{})
                   end, Stanzas).
 
 common_terminate(_Reason, #state{parser = Parser}) ->

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -255,6 +255,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 handle_data(Data, State = #state{parser = Parser,
                                  compress = Compress}) ->
+    Timestamp = os:system_time(micro_seconds),
     {ok, NewParser, Stanzas} =
         case Compress of
             false ->
@@ -267,7 +268,7 @@ handle_data(Data, State = #state{parser = Parser,
     escalus_connection:maybe_forward_to_owner(NewState#state.filter_pred,
                                               NewState,
                                               Stanzas,
-                                              fun forward_to_owner/2),
+                                              fun forward_to_owner/3, Timestamp),
     case lists:filter(fun is_stream_end/1, Stanzas) of
         [] -> {noreply, NewState};
         _ -> {stop, normal, NewState}
@@ -278,10 +279,11 @@ is_stream_end(#xmlstreamend{}) -> true;
 is_stream_end(_) -> false.
 
 forward_to_owner(Stanzas, #state{owner = Owner,
-                                 event_client = EventClient}) ->
+                                 event_client = EventClient}, Timestamp) ->
     lists:foreach(fun(Stanza) ->
                           escalus_event:incoming_stanza(EventClient, Stanza),
-                          Owner ! escalus_connection:stanza_msg(Stanza, #{})
+                          Owner ! escalus_connection:stanza_msg(Stanza,
+                                                                #{recv_timestamp => Timestamp})
                   end, Stanzas).
 
 common_terminate(_Reason, #state{parser = Parser}) ->

--- a/test/escalus_tcp_tests.erl
+++ b/test/escalus_tcp_tests.erl
@@ -19,9 +19,9 @@ interleave_msgs_and_rs_test() ->
     State = #state{owner = self(),
                    sm_state = {true, 0, active},
                    event_client = self()},
-    SecondState = escalus_tcp:forward_to_owner(FirstStanzas, State),
+    SecondState = escalus_tcp:forward_to_owner(FirstStanzas, State, os:system_time(micro_seconds)),
     #state{sm_state = SMState} =
-        escalus_tcp:forward_to_owner(SecondStanzas, SecondState),
+        escalus_tcp:forward_to_owner(SecondStanzas, SecondState, os:system_time(micro_seconds)),
     ?assertEqual({true, 3, active}, SMState),
     meck:unload(escalus_event),
     meck:unload(gen_tcp).

--- a/test/regressions_SUITE.erl
+++ b/test/regressions_SUITE.erl
@@ -15,7 +15,8 @@ all() ->
      %% can't run with current build system, see test for the rationale
      %% catch_assert_false,
      catch_escalus_user_verify_creation,
-     test_peek_stanzas].
+     test_peek_stanzas,
+     test_get_stanza_with_metadata].
 
 suite() ->
     escalus:suite().
@@ -94,6 +95,21 @@ test_peek_stanzas(Config) ->
           end),
     escalus:delete_users(Config, escalus:get_users([alice])).
 
+test_get_stanza_with_metadata(Config) ->
+    escalus:create_users(Config, escalus:get_users([alice])),
+    story(Config, [{alice, 1}],
+          fun (Alice) ->
+                  %% given
+                  Msg = <<"Haha, I'm talkin' to myself">>,
+                  %% when
+                  escalus:send(Alice, escalus_stanza:chat_to(Alice, Msg)),
+                  timer:sleep(50),
+                  %% then
+                  {Stanza, Metadata} = escalus_connection:get_stanza_with_metadata(Alice, msg_to_self, 5000),
+                  ?a(erlang:is_map(Metadata)),
+                  ?a(maps:is_key(recv_timestamp, Metadata))
+          end),
+    escalus:delete_users(Config, escalus:get_users([alice])).
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------

--- a/test/regressions_SUITE.erl
+++ b/test/regressions_SUITE.erl
@@ -109,7 +109,7 @@ actually_has_stanzas(_, []) ->
     true;
 actually_has_stanzas([], [_|_]) ->
     false;
-actually_has_stanzas([{stanza, _, P} | MTail], [P | PTail]) ->
+actually_has_stanzas([{stanza, _, P, _} | MTail], [P | PTail]) ->
     actually_has_stanzas(MTail, PTail);
 actually_has_stanzas([_ | MTail], [P | PTail]) ->
     actually_has_stanzas(MTail, [P | PTail]).


### PR DESCRIPTION
Currently there is only `recv_timestamp` in the metadata sent from transport process to the client using escalus. The timestamp is taken short after the transport receives the packet.