### PR TITLE
Fix CT stanza log printing

### DIFF
--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -121,7 +121,6 @@ do_wait_for_stanzas(#client{event_client=EventClient, jid=Jid, rcv_pid=Pid} = Cl
             do_wait_for_stanzas(Client, 0, Timeout, Acc);
         {Stanza, _} ->
             escalus_event:pop_incoming_stanza(EventClient, Stanza),
-            escalus_ct:log_stanza(Jid, in, Stanza),
             do_wait_for_stanzas(Client, Count - 1, Timeout, [Stanza|Acc])
         %% FIXME: stream error
     end.

--- a/src/escalus_ct.erl
+++ b/src/escalus_ct.erl
@@ -91,8 +91,7 @@ do_log_stanza(Jid, Direction, Stanza) ->
                        [ReportString, Stanza]),
                 ct:fail(Error)
         end,
-    ct:print(stanza_log, "~s~n~s", [ReportString, PrettyStanza]),
-    ct:log(stanza_log, "~s~n~s", [ReportString, PrettyStanza]).
+    ct:pal(stanza_log, "~s~n~s", [ReportString, PrettyStanza]).
 
 %% ------------- Common Test hack! -------------
 %% There is a bug in Common Test since 18.3, which causes links to be printed inside <pre/>.

--- a/src/escalus_ct.erl
+++ b/src/escalus_ct.erl
@@ -85,7 +85,7 @@ do_log_stanza(Jid, Direction, Stanza) ->
     ReportString = io_lib:format("~s ~p", [Jid, Direction]),
     PrettyStanza =
         try
-            list_to_binary(exml:to_pretty_iolist(Stanza))
+            iolist_to_binary(exml:to_pretty_iolist(Stanza))
         catch error:Error ->
                 ct:pal(error, "Cannot convert stanza to iolist: ~s~n~p",
                        [ReportString, Stanza]),


### PR DESCRIPTION
`exml:to_pretty_iolist/1` sometimes returns a binary not wrapped in a list. This binary was later provided to `list_to_binary/1` which caused a crash. The solution was to replace call to `list_to_binary/1` with `iolist_to_binary/1` which correctly deals with bare binaries.