### PR TITLE
include test case name in fresh user's name

### DIFF
--- a/src/escalus_fresh.erl
+++ b/src/escalus_fresh.erl
@@ -216,7 +216,7 @@ case_name_suffix(Config) ->
             <<"_unnamed_">>;
         Name when is_atom(Name) ->
             N = atom_to_binary(Name, unicode),
-            <<"_",N/binary,"_">>
+            <<"_", N/binary, "_">>
     end.
 
 


### PR DESCRIPTION
the users will be named with case name suffix, like:
- `alice_simpe_message_12.413`
- `bob_get_roster_9.155`

for better debugging purposes. It assumes that in `int_per_testcase/2` `escalus:init_per_testcase/2` was run