### PR TITLE
Log more detailed error in escalus_fresh:clean

### DIFF
--- a/src/escalus_ct.erl
+++ b/src/escalus_ct.erl
@@ -13,7 +13,8 @@
 -export([add_log_link/3,
          fail/1,
          get_config/1,
-         log_stanza/3]).
+         log_stanza/3,
+         log_error/2]).
 
 -define(APPNAME, escalus).
 
@@ -130,3 +131,6 @@ ct_log_timestamp({MS, S, US}) ->
     lists:flatten(io_lib:format("~4.10.0B-~2.10.0B-~2.10.0B "
                                 "~2.10.0B:~2.10.0B:~2.10.0B.~3.10.0B",
                                 [Year, Month, Day, Hour, Min, Sec, MilliSec])).
+
+log_error(Format, Args) ->
+    ct:pal(error, Format, Args).


### PR DESCRIPTION
Because this is not enough info

```erlang
----------------------------------------------------
2018-06-06 20:00:46.940
end_per_suite
{failed,{{badmatch,false},
         [{escalus_fresh,clean,0,
                         [{file,"/home/travis/build/esl/MongooseIM/big_tests/_build/default/lib/escalus/src/escalus_fresh.erl"},
                          {line,107}]},
          {amp_big_SUITE,end_per_suite,1,
                         [{file,"amp_big_SUITE.erl"},{line,109}]},
          {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1533}]},
          {test_server,run_test_case_eval1,6,
                       [{file,"test_server.erl"},{line,1138}]},
          {test_server,run_test_case_eval,9,
                       [{file,"test_server.erl"},{line,985}]}]}}
```