### PR TITLE
Pass ssl_opts to gun connections

### DIFF
--- a/src/escalus_bosh_gun.erl
+++ b/src/escalus_bosh_gun.erl
@@ -52,8 +52,9 @@ init([Args]) ->
     process_flag(trap_exit, true),
     Port = proplists:get_value(port, Args, 5280),
     Host = proplists:get_value(host, Args, <<"localhost">>),
+    GunOpts = gun_options(Args),
     {ok, #state{destination = {host_to_list(Host), Port},
-                options = gun_options(Args),
+                options = GunOpts,
                 total = 0,
                 max = 2,
                 free = [],
@@ -153,10 +154,12 @@ wait_for_response(Client, StreamRef) ->
     end.
 
 gun_options(Args) ->
+    SSLOpts = proplists:get_value(ssl_opts, Args, []),
     case proplists:get_value(ssl, Args, false) of
-        true ->
-            #{transport => tls};
-        _ ->
-            #{}
-    end.
+    true ->
+        #{transport => tls,
+          transport_opts => SSLOpts};
+    _ ->
+        #{}
+end.
 

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -164,14 +164,16 @@ init([Args, Owner]) ->
     LegacyWS = get_legacy_ws(Args, false),
     EventClient = proplists:get_value(event_client, Args),
     SSL = proplists:get_value(ssl, Args, false),
+    SSLOpts = proplists:get_value(ssl_opts, Args, []),
     %% Disable http2 in protocols
-    WSOptions = case SSL of
+    TransportOpts = case SSL of
                     true ->
-                        #{transport => tls, protocols => [http]};
+                        #{transport => tls, protocols => [http],
+                          transport_opts => SSLOpts};
                     _ ->
                         #{transport => tcp, protocols => [http]}
                 end,
-    {ok, ConnPid} = gun:open(Host, Port, WSOptions),
+    {ok, ConnPid} = gun:open(Host, Port, TransportOpts),
     {ok, http} = gun:await_up(ConnPid),
     WSUpgradeHeaders = [{<<"sec-websocket-protocol">>, <<"xmpp">>}],
     StreamRef = gun:ws_upgrade(ConnPid, Resource, WSUpgradeHeaders,


### PR DESCRIPTION
In this PR the `ssl_opts` used in a `UserSpec` are passed to the `gun` connection.