### PR TITLE
Upgrade exml to 3.0.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {require_otp_vsn, "(^19)|(^2[01])"}.
 
 {deps, [
-        {exml, {git, "https://github.com/esl/exml.git", {ref, "5059e8f"}}},
+        {exml, {git, "https://github.com/esl/exml.git", {tag, "3.0.3"}}},
         {base16, {git, "https://github.com/goj/base16.git", {ref, "ec420aa"}}},
         {fusco, {git, "https://github.com/esl/fusco.git", {ref, "0a428471"}}},
         {meck, {git, "https://github.com/eproxus/meck.git", {ref, "65b79f4"}}},


### PR DESCRIPTION
The new version of exml uses port compiler rebar3 plugin to compile nif library.
https://github.com/esl/exml/releases/tag/3.0.3