### PR TITLE
Reorganise send/receive functions

### DIFF
--- a/src/escalus_client.erl
+++ b/src/escalus_client.erl
@@ -152,30 +152,8 @@ send_iq_and_wait_for_result(Client, Iq) ->
 -spec send_iq_and_wait_for_result(client(), exml:element(), non_neg_integer()) ->
     exml:element() | no_return().
 send_iq_and_wait_for_result(Client, #xmlel{name = <<"iq">>} = Req, Timeout) ->
-    ok = send(Client, Req),
-    Resp = #xmlel{name = RespName} = wait_for_stanza(Client, Timeout),
-    RespType = exml_query:attr(Resp, <<"type">>, undefined),
-    RespId = exml_query:attr(Resp, <<"id">>),
-    ReqId = exml_query:attr(Req, <<"id">>),
-    case {RespName, RespType, RespId == ReqId} of
-        {<<"iq">>, <<"result">>, true} ->
-            Resp;
-        {<<"iq">>, <<"result">>, false} ->
-            raise_invalid_iq_resp_error(received_invalid_iq_result_id, ReqId, RespId, Req, Resp);
-        {<<"iq">>, _, _} ->
-            raise_invalid_iq_resp_error(received_invalid_iq_stanza_type, <<"result">>, RespType,
-                                        Req, Resp);
-        {_, _, _} ->
-            raise_invalid_iq_resp_error(received_invalid_stanza, <<"iq">>, RespName, Req, Resp)
-    end.
-
--spec raise_invalid_iq_resp_error(atom(), term(), term(), exml:element(), exml:element()) ->
-    no_return().
-raise_invalid_iq_resp_error(Reason, Expected, Received, Req, Resp) ->
-    error({Reason, [{expected, Expected},
-                    {received, Received},
-                    {request, Req},
-                    {response, Resp}]}).
+    escalus_connection:send_and_receive(Client, Req, #{timeout => Timeout,
+                                                       assert => {is_iq_result, [Req]}}).
 
 -spec is_client(term()) -> boolean().
 is_client(#client{}) ->

--- a/test/connection_SUITE.erl
+++ b/test/connection_SUITE.erl
@@ -1,0 +1,114 @@
+%% @doc Tests for escalus_connection
+
+-module(connection_SUITE).
+
+-include_lib("exml/include/exml_stream.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0,
+         groups/0]).
+
+-export([receive_stanza_timeout/1,
+         receive_stanza_timeout_safe/1,
+         receive_stanza_with_metadata/1,
+         receive_stanza_pred/1,
+         receive_stanza_assert/1,
+         receive_stanza_with_handler/1]).
+
+%% Common Test callbacks
+
+all() ->
+    [{group, basic}].
+
+groups() ->
+    [{basic, [parallel], [receive_stanza_timeout,
+                          receive_stanza_timeout_safe,
+                          receive_stanza_with_metadata,
+                          receive_stanza_pred,
+                          receive_stanza_assert,
+                          receive_stanza_with_handler]}].
+
+%% Test cases
+
+receive_stanza_timeout(_Config) ->
+    Client = client(),
+    Stanza = escalus_stanza:chat_to(my_jid(), msg()),
+    erlang:send_after(1000, self(), escalus_connection:stanza_msg(Stanza, metadata())),
+    ?assertException(throw, timeout, escalus_connection:receive_stanza(Client, #{timeout => 10})),
+    ?assertException(throw, {timeout, msg},
+                     escalus_connection:receive_stanza(Client, #{timeout => 10, name => msg})),
+    Stanza = escalus_connection:receive_stanza(Client, #{}).
+
+receive_stanza_timeout_safe(_Config) ->
+    Client = client(),
+    Stanza = escalus_stanza:chat_to(my_jid(), msg()),
+    erlang:send_after(1000, self(), escalus_connection:stanza_msg(Stanza, metadata())),
+    {error, timeout} = escalus_connection:receive_stanza(Client, #{timeout => 10, safe => true}),
+    Stanza = escalus_connection:receive_stanza(Client, #{}).
+
+receive_stanza_with_metadata(_Config) ->
+    Client = client(),
+    Stanza = escalus_stanza:chat_to(my_jid(), msg()),
+    Metadata = metadata(),
+    self() ! escalus_connection:stanza_msg(Stanza, Metadata),
+    {Stanza, Metadata} = escalus_connection:receive_stanza(Client, #{with_metadata => true}).
+
+receive_stanza_pred(_Config) ->
+    Client = client(),
+    SkippedStanza = escalus_stanza:chat_to(my_jid(), msg()),
+    Stanza = escalus_stanza:chat_to(my_jid(), msg2()),
+    self() ! escalus_connection:stanza_msg(SkippedStanza, metadata()),
+    self() ! escalus_connection:stanza_msg(Stanza, metadata()),
+    Pred = fun(S) -> escalus_pred:is_chat_message(msg2(), S) end,
+    Stanza = escalus_connection:receive_stanza(Client, #{pred => Pred}),
+    ?assertException(throw, timeout, escalus_connection:receive_stanza(Client, #{timeout => 10})).
+
+receive_stanza_assert(_Config) ->
+    Client = client(),
+    Stanza = escalus_stanza:chat_to(my_jid(), msg2()),
+    self() ! escalus_connection:stanza_msg(Stanza, metadata()),
+    ?assertException(error, {assertion_failed, assert, is_chat_message, _, _, _},
+                     escalus_connection:receive_stanza(Client, #{assert => {is_chat_message, [msg()]}})),
+    self() ! escalus_connection:stanza_msg(Stanza, metadata()),
+    Stanza = escalus_connection:receive_stanza(Client, #{assert => {is_chat_message, [msg2()]}}),
+    self() ! escalus_connection:stanza_msg(Stanza, metadata()),
+    Stanza = escalus_connection:receive_stanza(Client, #{assert => fun(S) -> S =:= Stanza end}),
+    self() ! escalus_connection:stanza_msg(Stanza, metadata()),
+    Stanza = escalus_connection:receive_stanza(Client, #{assert => is_chat_message}).
+
+receive_stanza_with_handler(_Config) ->
+    Handler = handler(fun(Msg) -> escalus_pred:is_chat_message(msg(), Msg) end,
+                      fun(Msg) -> self() ! {handled, Msg} end),
+    Client = set_received_handlers(client(), [Handler]),
+    HandledStanza = escalus_stanza:chat_to(my_jid(), msg()),
+    OtherStanza = escalus_stanza:chat_to(my_jid(), msg2()),
+    self() ! escalus_connection:stanza_msg(HandledStanza, metadata()),
+    self() ! escalus_connection:stanza_msg(OtherStanza, metadata()),
+    ?assertException(throw, timeout,
+                     escalus_connection:receive_stanza(Client, #{pred => fun(_) -> false end, timeout => 10})),
+    receive {handled, HandledStanza} -> ok after 0 -> ct:fail("not handled: ~p", [HandledStanza]) end.
+
+%% Helpers
+
+handler(Pred, Action) ->
+    fun(_Client, Msg) ->
+            case Pred(Msg) of
+                true -> Action(Msg), true;
+                false  -> false
+            end
+    end.
+
+my_jid() -> <<"alice@localhost">>.
+
+msg() -> <<"Message">>.
+
+msg2() -> <<"Message 2">>.
+
+metadata() -> #{recv_timestamp => os:system_time(micro_seconds)}.
+
+client() -> #client{jid = my_jid(), rcv_pid = self(), props = []}.
+
+set_received_handlers(Client, Handlers) ->
+    Client#client{props = [{received_stanza_handlers, Handlers}]}.


### PR DESCRIPTION
- Put receive options in a map
- Use the receive options in the send+receive function
- Keep send_iq_and_wait_for_result and get_stanza_* for backwards compatibility