### PR TITLE
Change escalus_tcp:send function to accept binary payload

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -17,6 +17,7 @@
          maybe_set_jid/1,
          send_and_receive/3,
          send/2,
+         send_raw/2,
          get_stanza/2,
          get_stanza/3,
          get_stanza/4,
@@ -206,6 +207,11 @@ send(#client{module = Mod, event_client = EventClient, rcv_pid = Pid, jid = Jid}
     escalus_ct:log_stanza(Jid, out, Elem),
     Mod:send(Pid, Elem),
     handle_stanza(Client, Elem, #{}, sent_stanza_handlers(Client)),
+    ok.
+
+-spec send_raw(escalus:client(), iodata()) -> ok.
+send_raw(#client{ module = Mod, rcv_pid = Pid }, Data) ->
+    Mod:send(Pid, Data),
     ok.
 
 -spec get_stanza(client(), any()) -> exml_stream:element().

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -209,7 +209,7 @@ send(#client{module = Mod, event_client = EventClient, rcv_pid = Pid, jid = Jid}
     handle_stanza(Client, Elem, #{}, sent_stanza_handlers(Client)),
     ok.
 
--spec send_raw(escalus:client(), iodata()) -> ok.
+-spec send_raw(escalus:client(), binary()) -> ok.
 send_raw(#client{ module = Mod, rcv_pid = Pid }, Data) ->
     Mod:send(Pid, Data),
     ok.

--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -193,7 +193,7 @@ maybe_set_jid(Client = #client{props = Props}) ->
             Client
     end.
 
--spec send_and_receive(client(), exml:element(), receive_options()) ->
+-spec send_and_receive(client(), exml_stream:element(), receive_options()) ->
                      {exml_stream:element(), metadata()} |
                      exml_stream:element() |
                      {error, timeout}.

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -83,7 +83,7 @@ connect(Opts0) ->
     {ok, Pid} = gen_server:start_link(?MODULE, [Opts1, self()], []),
     Pid.
 
--spec send(pid(), exml:element() | binary()) -> ok.
+-spec send(pid(), exml_stream:element() | iodata()) -> ok.
 send(Pid, ElemOrData) ->
     gen_server:cast(Pid, {send, ElemOrData}).
 
@@ -258,9 +258,7 @@ handle_call(stop, _From, S) ->
     wait_until_closed(S#state.socket),
     {stop, normal, ok, S}.
 
--type stream_level_element() :: exml:element() | exml_stream:start() | exml_stream:stop().
-
--spec handle_cast({send, stream_level_element() | iodata()}, state()) ->
+-spec handle_cast({send, exml_stream:element() | iodata()}, state()) ->
     {noreply, state()} | {stop, term(), state()}.
 handle_cast({send, Data}, #state{ on_request = OnRequestFun } = State)
   when is_binary(Data); is_list(Data) ->

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -9,6 +9,7 @@
 -behaviour(escalus_connection).
 
 -include_lib("exml/include/exml_stream.hrl").
+-include_lib("exml/include/exml.hrl").
 -include("escalus.hrl").
 
 %% API exports
@@ -82,9 +83,9 @@ connect(Opts0) ->
     {ok, Pid} = gen_server:start_link(?MODULE, [Opts1, self()], []),
     Pid.
 
--spec send(pid(), exml:element()) -> ok.
-send(Pid, Elem) ->
-    gen_server:cast(Pid, {send, Elem}).
+-spec send(pid(), exml:element() | binary()) -> ok.
+send(Pid, ElemOrData) ->
+    gen_server:cast(Pid, {send, ElemOrData}).
 
 -spec is_connected(pid()) -> boolean().
 is_connected(Pid) ->
@@ -258,22 +259,12 @@ handle_call(stop, _From, S) ->
     {stop, normal, ok, S}.
 
 
--spec handle_cast({send, any()}, any()) -> {noreply, state()} | {stop, term(), state()}.
-handle_cast({send, Elem}, #state{socket = Socket, ssl = Ssl, compress = Compress,
-                                 on_request = OnRequestFun} = State) ->
-    Reply = case {Ssl, Compress} of
-                {true, {zlib, {_, Zout}}} ->
-                    Deflated = zlib:deflate(Zout, exml:to_iolist(Elem), sync),
-                    ssl:send(Socket, Deflated);
-                {true, _} ->
-                    ssl:send(Socket, exml:to_iolist(Elem));
-                {false, {zlib, {_, Zout}}} ->
-                    Deflated = zlib:deflate(Zout, exml:to_iolist(Elem), sync),
-                    gen_tcp:send(State#state.socket, Deflated);
-                {false, false} ->
-                    gen_tcp:send(Socket, exml:to_iolist(Elem))
-            end,
-    OnRequestFun(Reply),
+-spec handle_cast({send, exml:element() | iodata()}, state()) ->
+    {noreply, state()} | {stop, term(), state()}.
+handle_cast({send, #xmlel{} = Elem}, State) ->
+    handle_cast({send, exml:to_iolist(Elem)}, State);
+handle_cast({send, Data}, #state{ on_request = OnRequestFun } = State) ->
+    OnRequestFun(maybe_compress_and_send(Data, State)),
     {noreply, State};
 handle_cast(reset_parser, #state{parser = Parser} = State) ->
     {ok, NewParser} = exml_stream:reset_parser(Parser),
@@ -436,16 +427,20 @@ reply_to_ack_requests({false,H,A}, _, _) -> {false, H, A};
 reply_to_ack_requests({true,H,inactive}, _, _) -> {true, H, inactive};
 reply_to_ack_requests({true, H0, active}, Acks, State) ->
     {true,
-     lists:foldl(fun({Ack,H}, _) -> raw_send(State, Ack), H end,
+     % TODO: Maybe compress here?
+     lists:foldl(fun({Ack,H}, _) -> raw_send(exml:to_iolist(Ack), State), H end,
                  H0, Acks),
      active}.
 
-raw_send(#state{socket=Socket, ssl=true}, Elem) ->
-    ssl:send(Socket, exml:to_iolist(Elem));
-raw_send(#state{socket=_Socket, compress=true}, _Elem) ->
-    throw({escalus_tcp, auto_ack_not_implemented_for_compressed_streams});
-raw_send(#state{socket=Socket}, Elem) ->
-    gen_tcp:send(Socket, exml:to_iolist(Elem)).
+maybe_compress_and_send(Data, #state{ compress = {zlib, {_, Zout}} } = State) ->
+    raw_send(zlib:deflate(Zout, Data, sync), State);
+maybe_compress_and_send(Data, State) ->
+    raw_send(Data, State).
+
+raw_send(Data, #state{socket = Socket, ssl = true}) ->
+    ssl:send(Socket, Data);
+raw_send(Data, #state{socket = Socket}) ->
+    gen_tcp:send(Socket, Data).
 
 common_terminate(_Reason, #state{parser = Parser}) ->
     exml_stream:free_parser(Parser).


### PR DESCRIPTION
See title.

Includes minor refactor of `escalus_tcp` internals.

Verified by https://github.com/esl/MongooseIM/pull/2304