### PR TITLE
Fix incorrect escalus:{create,delete}_users/2 spec propagated down to all impls

### DIFF
--- a/src/escalus.erl
+++ b/src/escalus.erl
@@ -96,7 +96,7 @@ end_per_testcase(_CaseName, Config) ->
 create_users(Config) ->
     escalus_users:create_users(Config).
 
--spec create_users(config(), escalus_users:user_spec()) -> config().
+-spec create_users(config(), [escalus_users:named_user()]) -> config().
 create_users(Config, Users) ->
     escalus_users:create_users(Config, Users).
 
@@ -104,13 +104,14 @@ create_users(Config, Users) ->
 delete_users(Config) ->
     escalus_users:delete_users(Config).
 
--spec delete_users(config(), escalus_users:user_spec()) -> config().
+-spec delete_users(config(), [escalus_users:named_user()]) -> config().
 delete_users(Config, Users) ->
     escalus_users:delete_users(Config, Users).
 
 -spec get_users(Names) -> Result when
-      Names :: all | [escalus_users:user_name()]
-               | {by_name, [escalus_users:user_name()]},
+      Names :: all
+             | [escalus_users:user_name()]
+             | {by_name, [escalus_users:user_name()]},
       Result :: [escalus_users:named_user()].
 get_users(Names) ->
     escalus_users:get_users(Names).

--- a/src/escalus_ejabberd.erl
+++ b/src/escalus_ejabberd.erl
@@ -47,8 +47,6 @@
          setup_option/2,
          reset_option/2]).
 
--type user_spec() :: escalus_users:user_spec().
-
 -include("escalus.hrl").
 
 %%%
@@ -208,18 +206,14 @@ reset_option({Option, _, Set, _}, Config) ->
 start(_) -> ok.
 stop(_) -> ok.
 
--spec create_users(escalus:config(), [user_spec()]) -> escalus:config().
+-spec create_users(escalus:config(), [escalus_users:named_user()]) -> escalus:config().
 create_users(Config, Users) ->
-    lists:foreach(fun({_Name, UserSpec}) ->
-                          register_user(Config, UserSpec)
-                  end, Users),
+    lists:foreach(fun (User) -> register_user(Config, User) end, Users),
     lists:keystore(escalus_users, 1, Config, {escalus_users, Users}).
 
--spec delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+-spec delete_users(escalus:config(), [escalus_users:named_user()]) -> escalus:config().
 delete_users(Config, Users) ->
-    lists:foreach(fun({_Name, UserSpec}) ->
-                          unregister_user(Config, UserSpec)
-                  end, Users),
+    lists:foreach(fun(User) -> unregister_user(Config, User) end, Users),
     Config.
 
 %%--------------------------------------------------------------------
@@ -236,13 +230,15 @@ name() -> ?MODULE.
 %% Helpers
 %%--------------------------------------------------------------------
 
-register_user(Config, UserSpec) ->
+-spec register_user(escalus:config(), escalus_users:named_user()) -> any().
+register_user(Config, {_UserName, UserSpec}) ->
     StrFormat = escalus_ct:get_config(ejabberd_string_format),
     USP = [unify_str_arg(Arg, StrFormat) ||
            Arg <- escalus_users:get_usp(Config, UserSpec)],
     rpc(ejabberd_admin, register, USP).
 
-unregister_user(Config, UserSpec) ->
+-spec unregister_user(escalus:config(), escalus_users:named_user()) -> any().
+unregister_user(Config, {_UserName, UserSpec}) ->
     StrFormat = escalus_ct:get_config(ejabberd_string_format),
     USP = [unify_str_arg(Arg, StrFormat) ||
            Arg <- escalus_users:get_usp(Config, UserSpec)],

--- a/src/escalus_user_db.erl
+++ b/src/escalus_user_db.erl
@@ -4,9 +4,7 @@
 %% For another implementation see ESL internal repository at
 %% https://gitlab.erlang-solutions.com/simon.zelazny/fake-auth-server.
 
--type user_spec() :: escalus_users:user_spec().
-
 -callback start(any()) -> any().
 -callback stop(any()) -> any().
--callback create_users(escalus:config(), [user_spec()]) -> escalus:config().
--callback delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+-callback create_users(escalus:config(), [escalus_users:named_user()]) -> escalus:config().
+-callback delete_users(escalus:config(), [escalus_users:named_user()]) -> escalus:config().

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -88,7 +88,7 @@ stop(Config) ->
             ok
     end.
 
--spec create_users(escalus:config(), [user_spec()]) -> escalus:config().
+-spec create_users(escalus:config(), [named_user()]) -> escalus:config().
 create_users(Config, Users) ->
     case auth_type(Config) of
         xmpp ->
@@ -97,13 +97,13 @@ create_users(Config, Users) ->
             M:create_users(Config, Users)
     end.
 
--spec create_users_via_xmpp(escalus:config(), [user_spec()]) -> escalus:config().
+-spec create_users_via_xmpp(escalus:config(), [named_user()]) -> escalus:config().
 create_users_via_xmpp(Config, Users) ->
     CreationResults = [create_user(Config, User) || User <- Users],
     lists:foreach(fun verify_creation/1, CreationResults),
     lists:keystore(escalus_users, 1, Config, {escalus_users, Users}).
 
--spec delete_users(escalus:config(), [user_spec()]) -> escalus:config().
+-spec delete_users(escalus:config(), [named_user()]) -> escalus:config().
 delete_users(Config, Users) ->
     case auth_type(Config) of
         xmpp ->
@@ -270,7 +270,7 @@ verify_creation({error, Error, Raw}) ->
     error_logger:error_msg("error when trying to register user: ~s~n", [RawStr]),
     error(Error).
 
--spec delete_user(escalus:config(), {atom(), user()}) ->
+-spec delete_user(escalus:config(), named_user()) ->
       {ok, _, _} | {error, _, _}.
 delete_user(Config, {_Name, UserSpec}) ->
     Options = get_options(Config, UserSpec),


### PR DESCRIPTION
This bug shows an interesting case of "specs as documentation" and the difference between how Dialyzer and Gradualizer treat them:

- Dialyzer does not report any errors, since indeed, the code works - MIM big tests confirm that, too.
- Gradualizer yells that there's an error, since indeed, the spec lies about the actually accepted parameters.

IMO, usability wise Gradualizer is more convenient to quickly catch programmer typos/mistakes since it takes way less time to run it. Moreover, it reinforces the "specs as documentation" approach, as it actually points out mistakes in the specs.