### PR TITLE
extend the timeout for the tcp connection

### DIFF
--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -52,7 +52,7 @@
 -type sm_state() :: {boolean(), non_neg_integer(), 'active'|'inactive'}.
 -export_type([sm_state/0]).
 
--define(WAIT_FOR_SOCKET_CLOSE_TIMEOUT, 200).
+-define(WAIT_FOR_SOCKET_CLOSE_TIMEOUT, 1000).
 -define(SERVER, ?MODULE).
 -include("escalus_tcp.hrl").
 


### PR DESCRIPTION
Under a heavily loaded system and with the weird tcp restrictions of the CI virtualization, 200ms is too tight of a timeout for receiving the `tcp_closed` message, hence some failures are being seen in `MIM:mam_SUITE` when multiple tests are massively ran in parallel and all keep the database, to which we also connect by tcp, loaded. Hence, we just need to expand it a bit. 1000ms has shown no failures in many thousands of rounds of tests.