### PR TITLE
Wait longer for stream start

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -480,7 +480,7 @@ default_connection_steps() ->
 start_stream(#client{module = Mod, props = Props} = Client) ->
     StreamStartReq = Mod:stream_start_req(Props),
     send(Client, StreamStartReq),
-    Timeout = proplists:get_value(wait_for_stream_timeout, Props, 1000),
+    Timeout = proplists:get_value(wait_for_stream_timeout, Props, 5000),
     StreamStartRep = get_stanza(Client, stream_start, Timeout),
     Mod:assert_stream_start(StreamStartRep, Props).
 

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -456,7 +456,10 @@ wait_until_closed(Socket) ->
         {tcp_closed, Socket} ->
             ok
     after ?WAIT_FOR_SOCKET_CLOSE_TIMEOUT ->
-            error(tcp_close_timeout)
+            %% Make warning, but allow process exit without an error.
+            %% There are many reasons for this to happen.
+            error_logger:warning_msg("tcp_close_timeout ~p~n", [Socket]),
+            {error, tcp_close_timeout}
     end.
 
 -spec host_to_inet(tuple() | atom() | list() | binary())


### PR DESCRIPTION
Tweaking timeouts.

- Make ws_upgrade_timeout configurable.
- Wait longer between socket is open and first data appears. Default 1 second assumes that server is really quick (or local). It would not work well with proxies or on slow network.
- All other timeouts are 5 seconds so...
- Ignore tcp_close_timeout (but raise a warning).