### PR TITLE
Ignore noproc when calling mark_as_terminated from bosh:kill

### DIFF
--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -122,8 +122,15 @@ stop(Pid) ->
 
 -spec kill(pid()) -> ok | already_stopped.
 kill(Pid) ->
-    mark_as_terminated(Pid),
-    stop(Pid).
+    try
+        mark_as_terminated(Pid),
+        stop(Pid)
+    catch
+        exit:{noproc, {gen_server, call, _}} ->
+            already_stopped;
+        exit:{normal, {gen_server, call, _}} ->
+            already_stopped
+    end.
 
 -spec upgrade_to_tls(_, _) -> no_return().
 upgrade_to_tls(_, _) ->


### PR DESCRIPTION
To be consistend with escalus_bosh:stop, escalus_ws:kill, escalus_ws:stop behaviour.

Avoids error like this:

```erlang
=== Ended at 2019-11-05 15:55:37
=== Location: [{gen_server,call,215},
              {escalus_bosh,kill,125},
              {escalus_client,kill_connection,81},
              {lists,foreach,1338},
              {escalus_story,story,67},
              {test_server,ts_tc,1748},
              {test_server,run_test_case_eval1,1263},
              {test_server,run_test_case_eval,1195}]
=== === Reason: {noproc,{gen_server,call,[<0.6588.0>,mark_as_terminated]}}

```