### PR TITLE
Do not crash when common test application is not running

### DIFF
--- a/src/escalus_ct.erl
+++ b/src/escalus_ct.erl
@@ -72,16 +72,26 @@ interpret_config_file_path(RelPath) ->
 -spec log_stanza(undefined | binary(), in | out, exml_stream:element()) -> ok.
 log_stanza(undefined, _, _) -> ok;
 log_stanza(Jid, Direction, Stanza) ->
-    case {is_ct_available(), ct:get_config(stanza_log)} of
-        {true, true} ->
-            do_log_stanza(console_and_file, Jid, Direction, Stanza);
-        {true, LogTarget}
-          when console_and_file == LogTarget;
-               console == LogTarget;
-               file == LogTarget ->
-            do_log_stanza(LogTarget, Jid, Direction, Stanza);
-        _ ->
-            ok
+    case get_stanza_log() of
+        false ->
+            ok;
+        LogTarget ->
+            do_log_stanza(LogTarget, Jid, Direction, Stanza)
+    end.
+
+get_stanza_log() ->
+    case is_ct_available() of
+        true ->
+            case ct:get_config(stanza_log, console_and_file) of
+                true ->
+                    console_and_file;
+                LogTarget when LogTarget == console_and_file;
+                               LogTarget == console;
+                               LogTarget == file  ->
+                    LogTarget
+            end;
+        false ->
+            false
     end.
 
 -spec is_ct_available() -> boolean().


### PR DESCRIPTION
Fixes:

```erlang
** Reason for termination ==
** {badarg,
       [{ets,select,
            [ct_attributes,
             [{{ct_conf,'_','$1','_','_',stanza_log,'_'},[],[{{'$1'}}]}]],
            []},
        {ct_config,lookup_name,1,[{file,"ct_config.erl"},{line,415}]},
        {ct_config,lookup_config,1,[{file,"ct_config.erl"},{line,407}]},
        {ct_config,get_config,3,[{file,"ct_config.erl"},{line,353}]},
        {ct_config,get_config,3,[{file,"ct_config.erl"},{line,337}]},
        {escalus_ct,log_stanza,3,
            [{file,
                 "/Users/mikhailuvarov/erlang/snatchbot/simulator/_build/default/lib/escalus/src/escalus_ct.erl"},
             {line,75}]},
        {escalus_connection,send,2,
            [{file,
                 "/Users/mikhailuvarov/erlang/snatchbot/simulator/_build/default/lib/escalus/src/escalus_connection.erl"},
             {line,207}]},
        {escalus_connection,start_stream,1,
            [{file,
                 "/Users/mikhailuvarov/erlang/snatchbot/simulator/_build/default/lib/escalus/src/escalus_connection.erl"},
             {line,482}]}]}
```

Introduced in:

```erlang
commit 689d63b0b2c903ed25f6d51bcc887f5ca57e5e1a
Author: Radek Szymczyszyn <radoslaw.szymczyszyn@erlang-solutions.com>
Date:   Wed Nov 13 15:41:15 2019 +0100
    Redirect stanza_log to a console, a file or both
```