### PR TITLE
Fix authentication features

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
   0},
  {<<"fast_tls">>,
   {git,"https://github.com/NelsonVides/fast_tls.git",
-       {ref,"d07db4a9c5243bebb020a865d3502b6f11e009bc"}},
+       {ref,"8b1ede952e4bffa012ba4418c81b37ae2a4ec871"}},
   0},
  {<<"fusco">>,
   {git,"https://github.com/esl/fusco.git",

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -43,7 +43,8 @@
          verify_creation/1,
          delete_user/2,
          get_usp/2,
-         is_mod_register_enabled/1
+         is_mod_register_enabled/1,
+         get_auth_method/1
         ]).
 
 %% Public types


### PR DESCRIPTION
```
Take into consideration the server offering and use the highest one
offered, unless the user has been configured to do otherwise explicitly.
```

Tested like this, on top of [today's MIM's master](https://github.com/esl/MongooseIM/commit/4755cf442e793be246c30dcfcb59a113663c1a1e):
```
(rebar3ct@Vides-MacBook-Pro)1> Specs = [{username, <<"alice">>}, {server, <<"localhost">>}, {host, <<"127.0.0.1">>}, {resource, <<"res1">>}, {password, <<"123456">>}, {carbons, false}, {stream_management, false}, {starttls, required}, {tls_module, fast_tls}].
(rebar3ct@Vides-MacBook-Pro)2> {ok, Client, Features} = escalus_connection:start(Specs).
{ok,{client,<<"alice@localhost/res1">>,escalus_tcp,
            <0.329.0>,undefined,
            [{username,<<"alice">>},
             {server,<<"localhost">>},
             {host,<<"127.0.0.1">>},
             {resource,<<"res1">>},
             {password,<<"123456">>},
             {carbons,false},
             {stream_management,false},
             {starttls,required},
             {tls_module,fast_tls},
             {stream_id,<<"FA4D11E5A2CC1192">>},
             {auth,{escalus_auth,auth_sasl_scram_sha512}}]},
    [{compression,[<<"zlib">>]},
     {starttls,false},
     {stream_management,true},
     {advanced_message_processing,true},
     {client_state_indication,false},
     {sasl_mechanisms,[<<"PLAIN">>,<<"DIGEST-MD5">>,
                       <<"SCRAM-SHA-1">>,<<"SCRAM-SHA-224">>,<<"SCRAM-SHA-256">>,
                       <<"SCRAM-SHA-384">>,<<"SCRAM-SHA-512">>]},
     {caps,undefined}]}
```

and in MIM we could see, setting the debug level to the maximum:
```
19:27:51.756 [debug] Received XML on stream = "<stream:stream to='localhost' version='1.0' xml:lang='en' xmlns='jabber:client' xmlns:stream='http://etherx.jabber. org/streams'>"
19:27:51.756 [debug] Send XML on stream = <<"<?xml version='1.0'?><stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' id='FA4D11E5A2CC1192' from='localhost' version='1.0' xml:lang='en'>">>
19:27:51.756 [debug] Send XML on stream = <<"<stream:features><compression xmlns='http://jabber.org/features/compress'><method>zlib</method></compression><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>PLAIN</mechanism><mechanism>DIGEST-MD5</mechanism><mechanism>SCRAM-SHA-1</mechanism><mechanism>SCRAM-SHA-224</mechanism><mechanism>SCRAM-SHA-256</mechanism><mechanism>SCRAM-SHA-384</mechanism><mechanism>SCRAM-SHA-512</mechanism></mechanisms><register xmlns='http://jabber.org/features/iq-register'/><amp xmlns='http://jabber.org/feature/amp'/><sm xmlns='urn:xmpp:sm:3'/></stream:features>">>
19:27:51.778 [debug] Received XML on stream = "<auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='SCRAM-SHA-512'>biwsbj1hbGljZSxyPTc2L1ZyMjlGK0plbnV2RkFGcklaTWc9PQ==</auth>"
19:27:51.807 [debug] Send XML on stream = <<"<challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>cj03Ni9WcjI5RitKZW51dkZBRnJJWk1nPT05MmQ3T3pTUHVOUGNSZHZVSmZSR2JBPT0scz0vZGVDK00vOHVISEdzQStybFprU0NBPT0saT00MDk2</challenge>">>
19:27:51.835 [debug] Received XML on stream = "<response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>Yz1iaXdzLHI9NzYvVnIyOUYrSmVudXZGQUZySVpNZz09OTJkN096U1B1TlBjUmR2VUpmUkdiQT09LHA9ZGZhNGVqY2VyTWZ1Q2E0bWtRcUFXV2hDRXdndWlBZU1XNzB3MjBDREYwclpSSHB6TlJ5VVhya2l6TFFVZno0Vy96Y04xS25jdG5MK0hDSGpHdHZDb0E9PQ==</response>"
19:27:51.835 [debug] Send XML on stream = <<"<success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>dj1SYmlUcE9aVGFsZHNVL2tiNk9LdmpCT3VSemUwdTBZMlV0RnpSaTY5OEVnSzUyWXFXOG5iZWdLd0hsZWlnbTkwVTVWZENLL05XVFlqQVgzd2Vlb2pjUT09</success>">>
```