### PR TITLE
Scram -PLUS variants

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -31,6 +31,7 @@
          get_sm_h/1,
          set_sm_h/2,
          set_filter_predicate/2,
+         get_tls_last_message/1,
          reset_parser/1,
          is_connected/1,
          wait_for_close/2,
@@ -379,6 +380,12 @@ set_sm_h(#client{module = Mod}, _) ->
 -spec set_filter_predicate(client(), filter_pred()) -> ok.
 set_filter_predicate(#client{module = Module, rcv_pid = Pid}, Pred) ->
     Module:set_filter_predicate(Pid, Pred).
+
+-spec get_tls_last_message(client()) -> {ok, binary()} | {error, undefined_tls_message}.
+get_tls_last_message(#client{module = escalus_tcp, rcv_pid = Pid}) ->
+    escalus_tcp:get_tls_last_message(Pid);
+get_tls_last_message(#client{}) ->
+    {error, undefined_tls_message}.
 
 -spec reset_parser(client()) -> ok.
 reset_parser(#client{module = Mod, rcv_pid = Pid}) ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -169,6 +169,7 @@ get_auth_method(<<"DIGEST-MD5">>) ->
     {escalus_auth, auth_digest_md5};
 get_auth_method(<<"SASL-ANON">>) ->
     {escalus_auth, auth_sasl_anon};
+%% SCRAM Regular
 get_auth_method(<<"SCRAM-SHA-1">>) ->
     {escalus_auth, auth_sasl_scram_sha1};
 get_auth_method(<<"SCRAM-SHA-224">>) ->
@@ -179,6 +180,17 @@ get_auth_method(<<"SCRAM-SHA-384">>) ->
     {escalus_auth, auth_sasl_scram_sha384};
 get_auth_method(<<"SCRAM-SHA-512">>) ->
     {escalus_auth, auth_sasl_scram_sha512};
+%% SCRAM PLUS
+get_auth_method(<<"SCRAM-SHA-1-PLUS">>) ->
+    {escalus_auth, auth_sasl_scram_sha1_plus};
+get_auth_method(<<"SCRAM-SHA-224-PLUS">>) ->
+    {escalus_auth, auth_sasl_scram_sha224_plus};
+get_auth_method(<<"SCRAM-SHA-256-PLUS">>) ->
+    {escalus_auth, auth_sasl_scram_sha256_plus};
+get_auth_method(<<"SCRAM-SHA-384-PLUS">>) ->
+    {escalus_auth, auth_sasl_scram_sha384_plus};
+get_auth_method(<<"SCRAM-SHA-512-PLUS">>) ->
+    {escalus_auth, auth_sasl_scram_sha512_plus};
 get_auth_method(<<"X-OAUTH">>) ->
     {escalus_auth, auth_sasl_oauth};
 get_auth_method({Mod, Fun}) when is_atom(Mod), is_atom(Fun) ->

--- a/src/scram.erl
+++ b/src/scram.erl
@@ -39,6 +39,7 @@
         ]).
 
 -type hash_type() :: crypto:sha1() | crypto:sha2().
+-export_type([hash_type/0]).
 
 -spec salted_password(hash_type(), binary(), binary(), non_neg_integer()) -> binary().
 salted_password(Hash, Password, Salt, IterationCount) ->


### PR DESCRIPTION
Here it is, here it is coming, at last, escalus is getting SCRAM -PLUS variants 🎉 

Following the instructions from @michalwski  in https://github.com/esl/escalus/pull/223#issuecomment-604364171, I tested with MetronomeIM as follows:
```erlang
()1 Spec =
        [{username, <<"escalus_vides">>},
         {server, <<"lightwitch.org">>},
         {host, <<"meaveen.lightwitch.org">>},
         {resource, <<"res1">>},
         {password, <<"THIS_IS_NOT_MY_REAL_PASSWORD">>},
         {carbons, false},
         {stream_management, false},
         {starttls, required},
         {auth, {escalus_auth, auth_sasl_scram_sha256_plus}}].
()2> {ok, Client, Features} = escalus_connection:start(Specs).
```
And connected successfully 🎉 

Right, so time for disclaimers: note that this works only with [fast_tls](https://github.com/processone/fast_tls) as the underlying TLS driver, as OTP's TLS doesn't have as of now an API to get the underlying message. In fact, `fast_tls` doesn't support it either, the code to do so is on a [dev branch in my fork](https://github.com/NelsonVides/fast_tls/tree/plus_road), and this works only with OpenSSL, as other native SSL drivers like BoringSSL or LibreSSL have different API's to get this data that I have not explored.

But now we can work on getting this all organized, the prototypes cleaned, the forks merged... 🙂 

Moving forward with https://github.com/esl/MongooseIM/issues/2442
@Neustradamus 😉 