### PR TITLE
Encode c attribute payload at once

### DIFF
--- a/src/escalus_auth.erl
+++ b/src/escalus_auth.erl
@@ -245,8 +245,8 @@ build_c_attribute(none, GS2Headers, _Conn) ->
     <<"c=", (base64:encode(GS2Headers))/binary>>;
 build_c_attribute(tls_unique, GS2Headers, Conn) ->
     {ok, FinishedTLS} = escalus_connection:get_tls_last_message(Conn),
-    <<"c=", (base64:encode(GS2Headers))/binary, (base64:encode(FinishedTLS))/binary>>.
-
+    B64Data = <<GS2Headers/binary, FinishedTLS/binary>>,
+    <<"c=", (base64:encode(B64Data))/binary>>.
 
 scram_sha_validate_server(HashMethod, SaltedPassword, AuthMessage, ServerSignature) ->
     ServerKey = scram:server_key(HashMethod, SaltedPassword),


### PR DESCRIPTION
```
   o  c: This REQUIRED attribute specifies the base64-encoded GS2 header
      and channel binding data.  It is sent by the client in its second
      authentication message.  The attribute data consist of:

      *  the GS2 header from the client's first message (recall that the
         GS2 header contains a channel binding flag and an optional
         authzid).  This header is going to include channel binding type
         prefix (see [RFC5056]), if and only if the client is using
         channel binding;

      *  followed by the external channel's channel binding data, if and
         only if the client is using channel binding.
```

What wasn't clear is if the two pieces are encoded together or not, and
I'm surprised it managed to connect to MetronomeIM as it was, I have no
idea why, but honestly it seems more natural to think that they would be
encoded together.