### PR TITLE
Channel binding flag depending on ssl driver

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
   0},
  {<<"fast_tls">>,
   {git,"https://github.com/processone/fast_tls.git",
-       {ref,"3a42d7d478853ea231fad466cf0e4b773909d806"}},
+       {ref,"ceb277f5b172d94ec2a0c8b13cfb7e887961b55a"}},
   0},
  {<<"fusco">>,
   {git,"https://github.com/esl/fusco.git",

--- a/src/escalus_auth.erl
+++ b/src/escalus_auth.erl
@@ -128,7 +128,7 @@ auth_sasl_scram(#{plus_variant := PlusVariant,
     Username = get_property(username, Props),
     Nonce = base64:encode(crypto:strong_rand_bytes(16)),
     ClientFirstMessageBare = csvkv:format([{<<"n">>, Username}, {<<"r">>, Nonce}], false),
-    GS2Header = scram_sha_auth_payload(PlusVariant),
+    GS2Header = scram_sha_auth_payload(proplists:get_value(tls_module, Props, ssl), PlusVariant),
     Payload = <<GS2Header/binary, ClientFirstMessageBare/binary>>,
     Stanza = escalus_stanza:auth(XMPPMethod, [base64_cdata(Payload)]),
     ok = escalus_connection:send(Conn, Stanza),
@@ -258,8 +258,9 @@ scram_sha_validate_server(HashMethod, SaltedPassword, AuthMessage, ServerSignatu
             false
     end.
 
-scram_sha_auth_payload(none) -> <<"y,,">>;
-scram_sha_auth_payload(tls_unique) -> <<"p=tls-unique,,">>.
+scram_sha_auth_payload(ssl, _) -> <<"n,,">>;
+scram_sha_auth_payload(fast_tls, none) -> <<"y,,">>;
+scram_sha_auth_payload(fast_tls, tls_unique) -> <<"p=tls-unique,,">>.
 
 hex_md5(Data) ->
     base16:encode(crypto:hash(md5, Data)).


### PR DESCRIPTION
If we're using a regular OTP's SSL driver, default to simply `n` as a flag; if `fast_tls`, then as required in the RFC, always notify client's support with either `y` or `p`. Also update fast_tls to master.

Quick and I believe nice fix to today's discussion 🙂 