### PR TITLE
Check for Mix.env/0

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,5 +1,5 @@
 %% Convert deps to Rebar 2 format if necessary
-case erlang:function_exported(rebar3, main, 1) of
+case erlang:function_exported(rebar3, main, 1) orelse erlang:function_exported('Elixir.Mix', env, 0) of
     true -> CONFIG;
     false ->
         R3Deps = proplists:get_value(deps, CONFIG),
@@ -8,7 +8,7 @@ case erlang:function_exported(rebar3, main, 1) of
         %% Rebar 3 accepts more dep formats than the match spec above.
         %% Pattern match failures in comprehensions filter out elements,
         %% so assert we didn't miss any deps.
-        if 
+        if
             length(R2Deps) == length(R3Deps) -> ok;
             length(R2Deps) /= length(R3Deps) ->
                 error("rebar.config.script: skipped some deps")


### PR DESCRIPTION
When using `escalus` as an Elixir dependency, Mix gags with:

```
Error evaluating Rebar config script ./rebar.config.script:18: evaluation failed with reason error:[114,101,98,97,114,46,99,111,110,102,105,103,46,115,99,114,105,112,116,58,32,115,107,105,112,112,101,100,32,115,111,109,101,32,100,101,112,115] and stacktrace [{erl_eval,do_apply,6,[{file,[101,114,108,95,101,118,97,108,46,101,114,108]},{line,680}]},{erl_eval,exprs,5,[{file,[101,114,108,95,101,118,97,108,46,101,114,108]},{line,126}]},{file,eval_stream2,6,[{file,[102,105,108,101,46,101,114,108]},{line,1393}]},{file,script,2,[{file,[102,105,108,101,46,101,114,108]},{line,1090}]},{'Elixir.File','cd!',2,[{file,[108,105,98,47,102,105,108,101,46,101,120]},{line,1544}]},{'Elixir.Mix.Rebar',eval_script,2,[{file,[108,105,98,47,109,105,120,47,114,101,98,97,114,46,101,120]},{line,196}]},{'Elixir.File','cd!',2,[{file,[108,105,98,47,102,105,108,101,46,101,120]},{line,1544}]},{'Elixir.Mix.Dep.Loader',rebar_dep,3,[{file,[108,105,98,47,109,105,120,47,100,101,112,47,108,111,97,100,101,114,46,101,120]},{line,338}]}]
Any dependencies defined in the script won't be available unless you add them to your Mix project
```

Which tranlates to `rebar.config.script: skipped some deps`

I added a check to `Mix.env/0`, which infers rebar3.

I have not tested this with rebar(2). Might be easier to just drop support for rebar2. Your call.
