### PR TITLE
Use modern stacktrace fetching

### DIFF
--- a/src/escalus_story.erl
+++ b/src/escalus_story.erl
@@ -74,8 +74,7 @@ story(ConfigIn, ResourceCounts, Story, Opts) ->
         post_story_checks(Config, Clients),
         escalus_server:post_story(Config),
         stop_clients(ConfigIn)
-    catch Class:Reason ->
-        Stacktrace = erlang:get_stacktrace(),
+    catch Class:Reason:Stacktrace ->
         escalus_event:print_history(ConfigIn),
         erlang:raise(Class, Reason, Stacktrace)
     after

--- a/src/escalus_utils.erl
+++ b/src/escalus_utils.erl
@@ -123,8 +123,8 @@ stanza_lines(Prefix, Stanzas) ->
 
 show_backtrace() ->
     try throw(catch_me)
-    catch _:_ ->
-        error_logger:info_msg("Backtrace:~n~p~n", [tl(erlang:get_stacktrace())])
+    catch _:_:S ->
+        error_logger:info_msg("Backtrace:~n~p~n", [tl(S)])
     end.
 
 -spec get_jid(jid_spec()) -> binary().


### PR DESCRIPTION
This is a critical issue. Since OTP20, `erlang:get_stacktrace/0` is
deprecated, and since OTP22, it strictly returns empty lists. This
clashes with the implementation of OTP's common_test, which relies on
the stacktrace to identify where an error happened. Was any error to be
thrown during the execution of a escalus story, the stacktrace list
would be empty and then crash here:
https://github.com/erlang/otp/blob/864a6303ea8c64ca821a0cc4a1d8fc9d19e6f430/lib/common_test/src/ct_framework.erl#L997
with a case_clause error, because there's no case expecting an empty
list, and then the error printed would be a horrendous:
```
=== Location: unknown
=== === Reason: {'EXIT',
                     {fw_error,
                         {ct_framework,error_notification,
                             {{case_clause,[]},
                              [{ct_framework,error_notification,4,
                                   [{file,"ct_framework.erl"},{line,997}]},
                % ...
```