### PR TITLE
Add folders for correct copy into hex.pm

### DIFF
--- a/src/escalus.app.src
+++ b/src/escalus.app.src
@@ -23,5 +23,13 @@
   {links, [{"Github", "https://github.com/esl/escalus"}]},
   {build_tools, ["make", "rebar"]},
   {mod, {escalus_app, []}},
-  {env, [{config_file, "priv/escalus.config"}]}
+  {env, [{config_file, "priv/escalus.config"}]},
+  %% rebar3_hex ?DEFAULT_FILES: https://github.com/erlef/rebar3_hex/blob/master/src/rebar3_hex_publish.erl#L22
+  {files, ["src", "c_src", "include", "rebar.config.script",
+           "priv", "rebar.config", "rebar.lock", "CHANGELOG*",
+           "changelog*" ,"README*", "readme*" ,"LICENSE*",
+           "license*", "NOTICE",
+           %% escalus
+           "thirdparty", "script", "mongooseim-escalus-test-1"
+  ]}
  ]}.


### PR DESCRIPTION
Fix issue when `escalus` loaded from `hex.pm`:
```erlang
====== Reason:    {test_case_failed,
                      {failed_to_copy,enoent,
                          "/MongooseIM/big_tests/_build/default/lib/escalus/thirdparty/xmlview/xv-browser.xsl",
                          "/MongooseIM/big_tests/ct_report/ct_run.test@pc.2021-07-30_20.44.50/big_tests.tests.rest_SUITE.logs/run.2021-07-30_20.44.53/log_private/../../../../xv-browser.xsl"}}
```