### PR TITLE
Wait until the stream is closed by the server on user removal

### DIFF
--- a/src/escalus_connection.erl
+++ b/src/escalus_connection.erl
@@ -34,6 +34,7 @@
          get_tls_last_message/1,
          reset_parser/1,
          is_connected/1,
+         wait_for_close/1,
          wait_for_close/2,
          kill/1,
          use_zlib/1,
@@ -423,6 +424,9 @@ use_zlib(#client{module = Mod, rcv_pid = Pid}) ->
 upgrade_to_tls(#client{module = Mod, rcv_pid = Pid, props = Props}) ->
     SSLOpts = proplists:get_value(ssl_opts, Props, []),
     Mod:upgrade_to_tls(Pid, SSLOpts).
+
+wait_for_close(Client) ->
+    wait_for_close(Client, default_timeout()).
 
 %% @doc Waits at most MaxWait ms for the client to be closed.
 %% Returns true if the client was disconnected, otherwise false.


### PR DESCRIPTION
When removing a user over XMPP, the server sends a stream error with the "User removed" message, and closes the stream afterwards. Wait until it happens to avoid having incoming messages in the queue that would cause the wpool process to crash when trying to handle them later.