### PR TITLE
Use rebar3_codecov 0.6.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,8 +18,8 @@
 ]}.
 
 %% To override the plugin as installed by worker_pool
-{plugins,
- [{rebar3_codecov, "0.3.0"}]}.
+{project_plugins,
+ [{rebar3_codecov, "0.6.0"}]}.
 
 {relx, [{release, {escalus, "0.0.1"},
          [escalus]},


### PR DESCRIPTION
Updates the dependency to the most recent.
Also uses project_plugins, so we don't pull the dep if escalus is a dep of another app.