### PR TITLE
Allow custom stream element attributes (+ equivalent for WS)

### DIFF
--- a/include/escalus_xmlns.hrl
+++ b/include/escalus_xmlns.hrl
@@ -12,6 +12,9 @@
 % Defined by XMPP Core (RFC 3920).
 -define(NS_XMPP, <<"http://etherx.jabber.org/streams">>).
 
+% Defined by XMPP Subprotocol for WebSocket (RFC 7395).
+-define(NS_FRAMING, <<"urn:ietf:params:xml:ns:xmpp-framing">>).
+
 -define(NS_STREAM_ERRORS, <<"urn:ietf:params:xml:ns:xmpp-streams">>).
 -define(NS_TLS, <<"urn:ietf:params:xml:ns:xmpp-tls">>).
 -define(NS_SASL, <<"urn:ietf:params:xml:ns:xmpp-sasl">>).

--- a/src/escalus_bosh.erl
+++ b/src/escalus_bosh.erl
@@ -141,8 +141,8 @@ set_filter_predicate(Pid, Pred) ->
 -spec stream_start_req(escalus_users:user_spec()) -> exml_stream:element().
 stream_start_req(Props) ->
     {server, Server} = lists:keyfind(server, 1, Props),
-    NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
-    escalus_stanza:stream_start(Server, NS).
+    Attrs = proplists:get_value(stream_attrs, Props, #{}),
+    escalus_stanza:stream_start(Server, Attrs).
 
 -spec stream_end_req(_) -> exml_stream:element().
 stream_end_req(_) ->

--- a/src/escalus_tcp.erl
+++ b/src/escalus_tcp.erl
@@ -170,8 +170,8 @@ use_zlib(Pid) ->
 -spec stream_start_req(escalus_users:user_spec()) -> exml_stream:element().
 stream_start_req(Props) ->
     {server, Server} = lists:keyfind(server, 1, Props),
-    NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
-    escalus_stanza:stream_start(Server, NS).
+    Attrs = proplists:get_value(stream_attrs, Props, #{}),
+    escalus_stanza:stream_start(Server, Attrs).
 
 -spec stream_end_req(_) -> exml_stream:element().
 stream_end_req(_) ->

--- a/src/escalus_users.erl
+++ b/src/escalus_users.erl
@@ -372,6 +372,7 @@ is_mod_register_enabled(Config) ->
                      | 'connection_steps'  %% [escalus_session:step()]
                      | 'parser_opts' %% a list of exml parser opts,
                                      %% e.g. infinite_stream
+                     | stream_attrs  %% XML attributes for <stream:stream> or open/close elements
                      | received_stanza_handlers %% list of escalus_connection:stanza_handler()
                      | sent_stanza_handlers %% similar as above but for sent stanzas
                      .

--- a/src/escalus_ws.erl
+++ b/src/escalus_ws.erl
@@ -128,19 +128,22 @@ use_zlib(Pid) ->
 -spec stream_start_req(escalus_users:user_spec()) -> exml_stream:element().
 stream_start_req(Props) ->
     {server, Server} = lists:keyfind(server, 1, Props),
+    Attrs = proplists:get_value(stream_attrs, Props, #{}),
     case proplists:get_value(wslegacy, Props, false) of
         true ->
-            NS = proplists:get_value(stream_ns, Props, <<"jabber:client">>),
-            escalus_stanza:stream_start(Server, NS);
+            escalus_stanza:stream_start(Server, Attrs);
         false ->
-            escalus_stanza:ws_open(Server)
+            escalus_stanza:ws_open(Server, Attrs)
     end.
 
 -spec stream_end_req(_) -> exml_stream:element().
 stream_end_req(Props) ->
     case proplists:get_value(wslegacy, Props, false) of
-        true -> escalus_stanza:stream_end();
-        false -> escalus_stanza:ws_close()
+        true ->
+            escalus_stanza:stream_end();
+        false ->
+            Attrs = maps:with([<<"xmlns">>], proplists:get_value(stream_attrs, Props, #{})),
+            escalus_stanza:ws_close(Attrs)
     end.
 
 -spec assert_stream_start(exml_stream:element(), _) -> exml_stream:element().


### PR DESCRIPTION
Allow custom stream element attributes.

These attributes apply to:
  - `<stream:stream>` tag for TCP
  - `<open>` and `<close>` elements for Websockets

Additionally, facilitate testing error conditions by allowing the `undefined` value for the server JID and attributes.
Such values result in the attributes being removed from the respective element.