### PR TITLE
Fix the 'hashes' namespace according to XEP-0300

### DIFF
--- a/include/escalus_xmlns.hrl
+++ b/include/escalus_xmlns.hrl
@@ -553,7 +553,8 @@
 -define(NS_FORWARD_0, <<"urn:xmpp:forward:0">>).
 
 % Defined by XEP-0300: Use of Cryptographic Hash Functions in XMPP
--define(NS_HASH, <<"urn:xmpp:hashes">>).
+-define(NS_HASH_2, <<"urn:xmpp:hashes:2">>).
+-define(NS_HASH_FUNCTION(Alg), <<"urn:xmpp:hash-function-text-names:", Alg/binary>>).
 
 % Defined by XEP-0313: Message Archive Management (MAM)
 -define(NS_MAM, <<"urn:xmpp:mam:0">>).

--- a/src/escalus_stanza.erl
+++ b/src/escalus_stanza.erl
@@ -975,14 +975,14 @@ caps(HashAlg, HashValue, v2) ->
     #xmlel{name = ~"c",
            attrs = #{~"xmlns" => ?NS_CAPS_2},
            children = [#xmlel{name = ~"hash",
-                              attrs = #{~"xmlns" => ?NS_HASH, ~"algo" => HashAlg},
+                              attrs = #{~"xmlns" => ?NS_HASH_2, ~"algo" => HashAlg},
                               children = [#xmlcdata{content = HashValue}]}]}.
 
 -spec caps_to_node(exml:element()) -> binary().
 caps_to_node(#xmlel{name = ~"c", attrs = #{~"xmlns" := ?NS_CAPS, ~"node" := Node, ~"ver" := Ver}}) ->
     <<Node/binary, $#, Ver/binary>>;
 caps_to_node(#xmlel{name = ~"c", attrs = #{~"xmlns" := ?NS_CAPS_2}} = Caps) ->
-    [HashEl | _] = exml_query:subelements_with_name_and_ns(Caps, ~"hash", ?NS_HASH),
+    [HashEl | _] = exml_query:subelements_with_name_and_ns(Caps, ~"hash", ?NS_HASH_2),
     HashAlg = exml_query:attr(HashEl, ~"algo"),
     HashVal = exml_query:cdata(HashEl),
     <<(?NS_CAPS_2)/binary, $#, HashAlg/binary, $., HashVal/binary>>.


### PR DESCRIPTION
Additionally, add a utility macro for hash-related namespaces.
I decided not to hardcode them to make the utility more flexible.

This PR is used in https://github.com/esl/MongooseIM/pull/4679